### PR TITLE
Fixed ordering of field and proto index map_items in map_list.

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexFile.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexFile.java
@@ -207,9 +207,9 @@ public class DexFile {
             try {
                 stringPool.write(indexWriter, offsetWriter);
                 typePool.write(indexWriter);
-                fieldPool.write(indexWriter);
                 typeListPool.write(offsetWriter);
                 protoPool.write(indexWriter);
+                fieldPool.write(indexWriter);
                 methodPool.write(indexWriter);
                 encodedArrayPool.write(offsetWriter);
                 annotationPool.write(offsetWriter);


### PR DESCRIPTION
Fixed map_item ordering. Should help with loading dex into dalvik.
