### PR TITLE
Make Utf8Utils thread-safe

### DIFF
--- a/dexlib/src/main/java/org/jf/dexlib/Util/ByteArrayInput.java
+++ b/dexlib/src/main/java/org/jf/dexlib/Util/ByteArrayInput.java
@@ -40,6 +40,9 @@ public class ByteArrayInput
     /** &gt;= 0; current read cursor */
     private int cursor;
 
+    /* buffer for reading UTF-8 strings */
+    private char[] buffer = null;
+
     /**
      * Constructs an instance with the given data
      *
@@ -291,7 +294,11 @@ public class ByteArrayInput
         //skip the terminating null
         cursor++;
 
-        return Utf8Utils.utf8BytesToString(data, startPosition, byteCount);
+        if (buffer == null || buffer.length < byteCount) {
+            buffer = new char[byteCount];
+        }
+
+        return Utf8Utils.utf8BytesToString(buffer, data, startPosition, byteCount);
     }
 
     /** {@inheritDoc} */

--- a/dexlib/src/main/java/org/jf/dexlib/Util/Utf8Utils.java
+++ b/dexlib/src/main/java/org/jf/dexlib/Util/Utf8Utils.java
@@ -68,23 +68,16 @@ public final class Utf8Utils {
         return result;
     }
 
-    private static char[] tempBuffer = null;
-
     /**
      * Converts an array of UTF-8 bytes into a string.
      *
-     * This method uses a global buffer to avoid having to allocate one every time, so it is *not* thread-safe
-     *
+     * @param buffer a buffer to hold the chars as they are read.  Make sure the length of the array is at least 'length'
      * @param bytes non-null; the bytes to convert
      * @param start the start index of the utf8 string to convert
      * @param length the length of the utf8 string to convert, not including any null-terminator that might be present
      * @return non-null; the converted string
      */
-    public static String utf8BytesToString(byte[] bytes, int start, int length) {
-        if (tempBuffer == null || tempBuffer.length < length) {
-            tempBuffer = new char[length];
-        }
-        char[] chars = tempBuffer;
+    public static String utf8BytesToString(char[] buffer, byte[] bytes, int start, int length) {
         int outAt = 0;
 
         for (int at = start; length > 0; /*at*/) {
@@ -157,11 +150,11 @@ public final class Utf8Utils {
                     return throwBadUtf8(v0, at);
                 }
             }
-            chars[outAt] = out;
+            buffer[outAt] = out;
             outAt++;
         }
 
-        return new String(chars, 0, outAt);
+        return new String(buffer, 0, outAt);
     }
 
     /**


### PR DESCRIPTION
Utf8Utils holds a static character buffer that it uses while parsing strings, which unfortunately causes issues when multiple threads are trying to instantiate DexFile.  Although it is somewhat hackish, this commit works around the issue while still avoiding an allocation on every call by making the buffer a field of ByteArrayInput and passing that into utf8BytesToString().
