### PR TITLE
Providing listings of indexed item values in DexBackedDexFile.

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedDexFile.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedDexFile.java
@@ -91,4 +91,84 @@ public class DexBackedDexFile implements DexFile {
             }
         };
     }
+
+    public Set<String> getStrings() {
+        final int stringCount = dexBuf.getStringCount();
+
+        return new FixedSizeSet<String>() {
+            @Override
+            public String readItem(int index) {
+                return dexBuf.getString(index);
+            }
+
+            @Override
+            public int size() {
+                return stringCount;
+            }
+        };
+    }
+
+    public Set<String> getTypes() {
+        final int typeCount = dexBuf.getTypeCount();
+
+        return new FixedSizeSet<String>() {
+            @Override
+            public String readItem(int index) {
+                return dexBuf.getType(index);
+            }
+
+            @Override
+            public int size() {
+                return typeCount;
+            }
+        };
+    }
+
+    public Set<String> getProtos() {
+        final int protoCount = dexBuf.getProtoCount();
+
+        return new FixedSizeSet<String>() {
+            @Override
+            public String readItem(int index) {
+                return dexBuf.getProto(index);
+            }
+
+            @Override
+            public int size() {
+                return protoCount;
+            }
+        };
+    }
+
+    public Set<String> getFields() {
+        final int fieldCount = dexBuf.getFieldCount();
+
+        return new FixedSizeSet<String>() {
+            @Override
+            public String readItem(int index) {
+                return dexBuf.getField(index);
+            }
+
+            @Override
+            public int size() {
+                return fieldCount;
+            }
+        };
+    }
+
+    public Set<String> getMethods() {
+        final int methodCount = dexBuf.getMethodCount();
+
+        return new FixedSizeSet<String>() {
+            @Override
+            public String readItem(int index) {
+                return dexBuf.getMethod(index);
+            }
+
+            @Override
+            public int size() {
+                return methodCount;
+            }
+        };
+    }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBuffer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBuffer.java
@@ -245,6 +245,10 @@ public class DexBuffer {
         return ret;
     }
 
+    public int getStringCount() {
+        return stringCount;
+    }
+
     @Nullable
     public String getOptionalType(int typeIndex) {
         if (typeIndex == -1) {
@@ -268,6 +272,21 @@ public class DexBuffer {
         return getString(stringIndex);
     }
 
+    public int getTypeCount() {
+        return typeCount;
+    }
+
+    @Nonnull
+    public String getProto(int typeIndex) {
+        int protoOffset = getProtoIdItemOffset(typeIndex);
+        int stringIndex = readSmallUint(protoOffset);
+        return getString(stringIndex);
+    }
+
+    public int getProtoCount() {
+        return protoCount;
+    }
+
     @Nonnull
     public String getField(int fieldIndex) {
         int fieldOffset = getFieldIdItemOffset(fieldIndex);
@@ -283,6 +302,10 @@ public class DexBuffer {
         sb.append(":");
         sb.append(fieldType);
         return sb.toString();
+    }
+
+    public int getFieldCount() {
+        return fieldCount;
     }
 
     @Nonnull
@@ -315,6 +338,10 @@ public class DexBuffer {
         sb.append(")");
         sb.append(returnType);
         return sb.toString();
+    }
+
+    public int getMethodCount() {
+        return methodCount;
     }
 
     @Nonnull


### PR DESCRIPTION
Detailed listings of indexed items. Useful if one needs to compare modified dex file with the original, especially when item counts do not match.
