### PR TITLE
Check recursive super class to prevent overflow

### DIFF
--- a/dexlib/src/main/java/org/jf/dexlib/ClassDefItem.java
+++ b/dexlib/src/main/java/org/jf/dexlib/ClassDefItem.java
@@ -287,7 +287,8 @@ public class ClassDefItem extends Item<ClassDefItem> {
                 ClassDefItem superClassDefItem = unplacedClassDefsByType.get(superType);
 
                 if (superClassDefItem != null) {
-                    placeClass(superClassDefItem);
+                    if (!superClassDefItem.equals(classDefItem))
+                        placeClass(superClassDefItem);
                 }
 
                 TypeListItem interfaces = classDefItem.implementedInterfaces;


### PR DESCRIPTION
If a smali class extends itself, it leads to a stack overflow. The following smali file (just two lines) will reproduce this bug.

.class public Lsmali_breaker;
.super Lsmali_breaker;
