### PR TITLE
Make AnalysisTest.java cross-platform safe

### DIFF
--- a/baksmali/src/test/java/org/jf/baksmali/AnalysisTest.java
+++ b/baksmali/src/test/java/org/jf/baksmali/AnalysisTest.java
@@ -104,7 +104,8 @@ public class AnalysisTest {
                     className.substring(1, className.length() - 1));
             String smaliContents = readResource(smaliPath);
 
-            Assert.assertEquals(smaliContents.replace("\r\n", "\n"), stringWriter.toString().replace("\r\n", "\n"));
+            Assert.assertEquals(smaliContents.replace("\r", "").replace("\n", System.lineSeparator()),
+                    stringWriter.toString().replace("\r", "").replace("\n", System.lineSeparator()));
         }
     }
 


### PR DESCRIPTION
Use System.lineSeparator() for cross-platform safe EOL handling in runTest(). The patch fixes failing build attempts (`org.jf.baksmali.AnalysisTest > DuplicateTest FAILED [junit.framework.ComparisonFailure at AnalysisTest.java:107]`) on Windows systems.
