### PR TITLE
Implement dex entry for non classes.dex files

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/baksmaliOptions.java
+++ b/baksmali/src/main/java/org/jf/baksmali/baksmaliOptions.java
@@ -54,6 +54,7 @@ public class baksmaliOptions {
 
     public int apiLevel = 15;
     public String outputDirectory = "out";
+    public String dexEntry = "classes.dex";
     public List<String> bootClassPathDirs = Lists.newArrayList();
 
     public List<String> bootClassPathEntries = Lists.newArrayList();

--- a/baksmali/src/main/java/org/jf/baksmali/main.java
+++ b/baksmali/src/main/java/org/jf/baksmali/main.java
@@ -208,6 +208,9 @@ public class main {
                 case 't':
                     options.useImplicitReferences = false;
                     break;
+                case 'e':
+                    options.dexEntry = commandLine.getOptionValue("e");
+                    break;
                 case 'N':
                     disassemble = false;
                     break;
@@ -251,7 +254,7 @@ public class main {
         }
 
         //Read in and parse the dex file
-        DexBackedDexFile dexFile = DexFileFactory.loadDexFile(dexFileFile, options.apiLevel);
+        DexBackedDexFile dexFile = DexFileFactory.loadDexFile(dexFileFile, options.dexEntry, options.apiLevel);
 
         if (dexFile.isOdexFile()) {
             if (!options.deodex) {
@@ -450,6 +453,12 @@ public class main {
                 .withArgName("FILE")
                 .create("T");
 
+        Option dexEntryOption = OptionBuilder.withLongOpt("dex-file")
+                .withDescription("looks for dex file named DEX_FILE, defaults to classes.dex")
+                .withArgName("DEX_FILE")
+                .hasArg()
+                .create("e");
+
         basicOptions.addOption(versionOption);
         basicOptions.addOption(helpOption);
         basicOptions.addOption(outputDirOption);
@@ -467,6 +476,7 @@ public class main {
         basicOptions.addOption(jobsOption);
         basicOptions.addOption(resourceIdFilesOption);
         basicOptions.addOption(noImplicitReferencesOption);
+        basicOptions.addOption(dexEntryOption);
 
         debugOptions.addOption(dumpOption);
         debugOptions.addOption(ignoreErrorsOption);

--- a/dexlib2/src/main/java/org/jf/dexlib2/DexFileFactory.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/DexFileFactory.java
@@ -46,16 +46,21 @@ import java.util.zip.ZipFile;
 public final class DexFileFactory {
     @Nonnull
     public static DexBackedDexFile loadDexFile(String path, int api) throws IOException {
-        return loadDexFile(new File(path), new Opcodes(api));
+        return loadDexFile(new File(path), "classes.dex", new Opcodes(api));
     }
 
     @Nonnull
     public static DexBackedDexFile loadDexFile(File dexFile, int api) throws IOException {
-        return loadDexFile(dexFile, new Opcodes(api));
+        return loadDexFile(dexFile, "classes.dex", new Opcodes(api));
     }
 
     @Nonnull
-    public static DexBackedDexFile loadDexFile(File dexFile, @Nonnull Opcodes opcodes) throws IOException {
+    public static DexBackedDexFile loadDexFile(File dexFile, String dexEntry, int api) throws IOException {
+        return loadDexFile(dexFile, dexEntry, new Opcodes(api));
+    }
+
+    @Nonnull
+    public static DexBackedDexFile loadDexFile(File dexFile, String dexEntry, @Nonnull Opcodes opcodes) throws IOException {
         ZipFile zipFile = null;
         boolean isZipFile = false;
         try {
@@ -63,16 +68,16 @@ public final class DexFileFactory {
             // if we get here, it's safe to assume we have a zip file
             isZipFile = true;
 
-            ZipEntry zipEntry = zipFile.getEntry("classes.dex");
+            ZipEntry zipEntry = zipFile.getEntry(dexEntry);
             if (zipEntry == null) {
                 throw new NoClassesDexException("zip file %s does not contain a classes.dex file", dexFile.getName());
             }
             long fileLength = zipEntry.getSize();
             if (fileLength < 40) {
                 throw new ExceptionWithContext(
-                        "The classes.dex file in %s is too small to be a valid dex file", dexFile.getName());
+                        "The " + dexEntry + " file in %s is too small to be a valid dex file", dexFile.getName());
             } else if (fileLength > Integer.MAX_VALUE) {
-                throw new ExceptionWithContext("The classes.dex file in %s is too large to read in", dexFile.getName());
+                throw new ExceptionWithContext("The " + dexEntry + " file in %s is too large to read in", dexFile.getName());
             }
             byte[] dexBytes = new byte[(int)fileLength];
             ByteStreams.readFully(zipFile.getInputStream(zipEntry), dexBytes);


### PR DESCRIPTION
Adds support to disassemble APKs that have multiple dex files or non-standard naming.

Allows for

`baksmali -E classes2.dex filename`

Which would disassemble the internal `classes2.dex` file to `out`.
While setting default to `classes.dex`.
