### PR TITLE
Update doedexerant makefile

### DIFF
--- a/deodexerant/Android.mk
+++ b/deodexerant/Android.mk
@@ -39,4 +39,6 @@ LOCAL_SHARED_LIBRARIES := libdl
 
 LOCAL_MODULE_TAGS := optional
 
+LOCAL_LDFLAGS := -Wl,--hash-style=sysv
+
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Fixes "CANNOT LINK EXECUTABLE: empty/missing DT_HASH in "./deodexerant" (build with --hash-style=gnu?)" error