### PR TITLE
README link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The primary webpage is http://smali.googlecode.com, and the source is also mirro
 
 #### Some useful links for getting started with smali
 
-- [Official dex bytecode reference](http://s.android.com/tech/dalvik/dalvik-bytecode.html)
+- [Official dex bytecode reference](https://source.android.com/devices/tech/dalvik/dalvik-bytecode.html)
 - [Registers wiki page](https://code.google.com/p/smali/wiki/Registers)
 - [Types, Methods and Fields wiki page](https://code.google.com/p/smali/wiki/TypesMethodsAndFields)
-- [Official dex format reference](http://s.android.com/tech/dalvik/dex-format.html)
+- [Official dex format reference](https://source.android.com/devices/tech/dalvik/dex-format.html)


### PR DESCRIPTION
`Official dex bytecode reference`, `Official dex format reference` link fix