### PR TITLE
squid:HiddenFieldCheck - Local variables should not shadow class fields

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/ClassDefinition.java
@@ -64,7 +64,7 @@ public class ClassDefinition {
 
     @Nonnull
     private HashSet<String> findFieldsSetInStaticConstructor() {
-        HashSet<String> fieldsSetInStaticConstructor = new HashSet<String>();
+        HashSet<String> fieldsSetInStaticConstructorLocal = new HashSet<String>();
 
         for (Method method: classDef.getDirectMethods()) {
             if (method.getName().equals("<clinit>")) {
@@ -89,7 +89,7 @@ public class ClassDefinition {
                                 }
                                 if (fieldRef != null &&
                                         fieldRef.getDefiningClass().equals((classDef.getType()))) {
-                                    fieldsSetInStaticConstructor.add(ReferenceUtil.getShortFieldDescriptor(fieldRef));
+                                    fieldsSetInStaticConstructorLocal.add(ReferenceUtil.getShortFieldDescriptor(fieldRef));
                                 }
                                 break;
                             }
@@ -98,7 +98,7 @@ public class ClassDefinition {
                 }
             }
         }
-        return fieldsSetInStaticConstructor;
+        return fieldsSetInStaticConstructorLocal;
     }
 
     public void writeTo(IndentingWriter writer) throws IOException {

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItem.java
@@ -394,95 +394,95 @@ public class InstructionMethodItem<T extends Instruction> extends MethodItem {
     }
 
     protected void writeInvokeRegisters(IndentingWriter writer) throws IOException {
-        FiveRegisterInstruction instruction = (FiveRegisterInstruction)this.instruction;
-        final int regCount = instruction.getRegisterCount();
+        FiveRegisterInstruction instructionLocal = (FiveRegisterInstruction)this.instruction;
+        final int regCount = instructionLocal.getRegisterCount();
 
         writer.write('{');
         switch (regCount) {
             case 1:
-                writeRegister(writer, instruction.getRegisterC());
+                writeRegister(writer, instructionLocal.getRegisterC());
                 break;
             case 2:
-                writeRegister(writer, instruction.getRegisterC());
+                writeRegister(writer, instructionLocal.getRegisterC());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterD());
+                writeRegister(writer, instructionLocal.getRegisterD());
                 break;
             case 3:
-                writeRegister(writer, instruction.getRegisterC());
+                writeRegister(writer, instructionLocal.getRegisterC());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterD());
+                writeRegister(writer, instructionLocal.getRegisterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterE());
+                writeRegister(writer, instructionLocal.getRegisterE());
                 break;
             case 4:
-                writeRegister(writer, instruction.getRegisterC());
+                writeRegister(writer, instructionLocal.getRegisterC());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterD());
+                writeRegister(writer, instructionLocal.getRegisterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterE());
+                writeRegister(writer, instructionLocal.getRegisterE());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterF());
+                writeRegister(writer, instructionLocal.getRegisterF());
                 break;
             case 5:
-                writeRegister(writer, instruction.getRegisterC());
+                writeRegister(writer, instructionLocal.getRegisterC());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterD());
+                writeRegister(writer, instructionLocal.getRegisterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterE());
+                writeRegister(writer, instructionLocal.getRegisterE());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterF());
+                writeRegister(writer, instructionLocal.getRegisterF());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterG());
+                writeRegister(writer, instructionLocal.getRegisterG());
                 break;
         }
         writer.write('}');
     }
 
     protected void writeInvoke25xRegisters(IndentingWriter writer) throws IOException {
-        OneFixedFourParameterRegisterInstruction instruction =
+        OneFixedFourParameterRegisterInstruction instructionLocal =
                 (OneFixedFourParameterRegisterInstruction)this.instruction;
-        final int parameterRegCount = instruction.getParameterRegisterCount();
+        final int parameterRegCount = instructionLocal.getParameterRegisterCount();
 
-        writeRegister(writer, instruction.getRegisterFixedC());  // fixed register always present
+        writeRegister(writer, instructionLocal.getRegisterFixedC());  // fixed register always present
 
         writer.write(", {");
         switch (parameterRegCount) {
             case 1:
-                writeRegister(writer, instruction.getRegisterParameterD());
+                writeRegister(writer, instructionLocal.getRegisterParameterD());
                 break;
             case 2:
-                writeRegister(writer, instruction.getRegisterParameterD());
+                writeRegister(writer, instructionLocal.getRegisterParameterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterE());
+                writeRegister(writer, instructionLocal.getRegisterParameterE());
                 break;
             case 3:
-                writeRegister(writer, instruction.getRegisterParameterD());
+                writeRegister(writer, instructionLocal.getRegisterParameterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterE());
+                writeRegister(writer, instructionLocal.getRegisterParameterE());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterF());
+                writeRegister(writer, instructionLocal.getRegisterParameterF());
                 break;
             case 4:
-                writeRegister(writer, instruction.getRegisterParameterD());
+                writeRegister(writer, instructionLocal.getRegisterParameterD());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterE());
+                writeRegister(writer, instructionLocal.getRegisterParameterE());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterF());
+                writeRegister(writer, instructionLocal.getRegisterParameterF());
                 writer.write(", ");
-                writeRegister(writer, instruction.getRegisterParameterG());
+                writeRegister(writer, instructionLocal.getRegisterParameterG());
                 break;
         }
         writer.write('}');
     }
 
     protected void writeInvokeRangeRegisters(IndentingWriter writer) throws IOException {
-        RegisterRangeInstruction instruction = (RegisterRangeInstruction)this.instruction;
+        RegisterRangeInstruction instructionLocal = (RegisterRangeInstruction)this.instruction;
 
-        int regCount = instruction.getRegisterCount();
+        int regCount = instructionLocal.getRegisterCount();
         if (regCount == 0) {
             writer.write("{}");
         } else {
-            int startRegister = instruction.getStartRegister();
+            int startRegister = instructionLocal.getStartRegister();
             methodDef.registerFormatter.writeRegisterRange(writer, startRegister, startRegister+regCount-1);
         }
     }

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/PackedSwitchMethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/PackedSwitchMethodItem.java
@@ -55,11 +55,11 @@ public class PackedSwitchMethodItem extends InstructionMethodItem<PackedSwitchPa
         targets = new ArrayList<PackedSwitchTarget>();
 
         boolean first = true;
-        int firstKey = 0;
+        int firstKeyLocal = 0;
         if (baseCodeAddress >= 0) {
             for (SwitchElement switchElement: instruction.getSwitchElements()) {
                 if (first) {
-                    firstKey = switchElement.getKey();
+                    firstKeyLocal = switchElement.getKey();
                     first = false;
                 }
                 LabelMethodItem label = methodDef.getLabelCache().internLabel(
@@ -71,13 +71,13 @@ public class PackedSwitchMethodItem extends InstructionMethodItem<PackedSwitchPa
             commentedOut = true;
             for (SwitchElement switchElement: instruction.getSwitchElements()) {
                 if (first) {
-                    firstKey = switchElement.getKey();
+                    firstKeyLocal = switchElement.getKey();
                     first = false;
                 }
                 targets.add(new PackedSwitchOffsetTarget(switchElement.getOffset()));
             }
         }
-        this.firstKey = firstKey;
+        this.firstKey = firstKeyLocal;
     }
 
     @Override

--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/MethodDefinition.java
@@ -472,11 +472,11 @@ public class MethodDefinition {
             analysisException.printStackTrace(System.err);
         }
 
-        List<AnalyzedInstruction> instructions = methodAnalyzer.getAnalyzedInstructions();
+        List<AnalyzedInstruction> instructionsLocal = methodAnalyzer.getAnalyzedInstructions();
 
         int currentCodeAddress = 0;
-        for (int i=0; i<instructions.size(); i++) {
-            AnalyzedInstruction instruction = instructions.get(i);
+        for (int i=0; i<instructionsLocal.size(); i++) {
+            AnalyzedInstruction instruction = instructionsLocal.get(i);
 
             MethodItem methodItem = InstructionMethodItemFactory.makeInstructionFormatMethodItem(
                     this, currentCodeAddress, instruction.getInstruction());
@@ -489,7 +489,7 @@ public class MethodDefinition {
                                 this, currentCodeAddress, instruction.getOriginalInstruction())));
             }
 
-            if (i != instructions.size() - 1) {
+            if (i != instructionsLocal.size() - 1) {
                 methodItems.add(new BlankMethodItem(currentCodeAddress));
             }
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/AnalyzedInstruction.java
@@ -302,9 +302,9 @@ public class AnalyzedInstruction implements Comparable<AnalyzedInstruction> {
             return false;
         }
 
-        ReferenceInstruction instruction = (ReferenceInstruction)this.instruction;
+        ReferenceInstruction instructionLocal = (ReferenceInstruction)this.instruction;
 
-        Reference reference = instruction.getReference();
+        Reference reference = instructionLocal.getReference();
         if (reference instanceof MethodReference) {
             return ((MethodReference)reference).getName().equals("<init>");
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ArrayProto.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ArrayProto.java
@@ -121,8 +121,8 @@ public class ArrayProto implements TypeProto {
                 return classPath.getClass(makeArrayType(mergedClass.getType(), dimensions));
             }
 
-            int dimensions = Math.min(this.dimensions, ((ArrayProto)other).dimensions);
-            return classPath.getClass(makeArrayType("Ljava/lang/Object;", dimensions));
+            int dimensionsLocal = Math.min(this.dimensions, ((ArrayProto)other).dimensions);
+            return classPath.getClass(makeArrayType("Ljava/lang/Object;", dimensionsLocal));
         }
 
         if (other instanceof ClassProto) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
@@ -103,16 +103,16 @@ public class MethodAnalyzer {
 
         this.method = method;
 
-        MethodImplementation methodImpl = method.getImplementation();
-        if (methodImpl == null) {
+        MethodImplementation methodImplLocal = method.getImplementation();
+        if (methodImplLocal == null) {
             throw new IllegalArgumentException("The method has no implementation");
         }
 
-        this.methodImpl = methodImpl;
+        this.methodImpl = methodImplLocal;
 
         //override AnalyzedInstruction and provide custom implementations of some of the methods, so that we don't
         //have to handle the case this special case of instruction being null, in the main class
-        startOfMethod = new AnalyzedInstruction(null, -1, methodImpl.getRegisterCount()) {
+        startOfMethod = new AnalyzedInstruction(null, -1, methodImplLocal.getRegisterCount()) {
             public boolean setsRegister() {
                 return false;
             }
@@ -142,28 +142,28 @@ public class MethodAnalyzer {
     }
 
     private void analyze() {
-        Method method = this.method;
-        MethodImplementation methodImpl = this.methodImpl;
+        Method methodLocal = this.method;
+        MethodImplementation methodImplLocal = this.methodImpl;
 
-        int totalRegisters = methodImpl.getRegisterCount();
+        int totalRegisters = methodImplLocal.getRegisterCount();
         int parameterRegisters = paramRegisterCount;
 
         int nonParameterRegisters = totalRegisters - parameterRegisters;
 
         //if this isn't a static method, determine which register is the "this" register and set the type to the
         //current class
-        if (!MethodUtil.isStatic(method)) {
+        if (!MethodUtil.isStatic(methodLocal)) {
             int thisRegister = totalRegisters - parameterRegisters;
 
             //if this is a constructor, then set the "this" register to an uninitialized reference of the current class
-            if (MethodUtil.isConstructor(method)) {
+            if (MethodUtil.isConstructor(methodLocal)) {
                 setPostRegisterTypeAndPropagateChanges(startOfMethod, thisRegister,
                         RegisterType.getRegisterType(RegisterType.UNINIT_THIS,
-                                classPath.getClass(method.getDefiningClass())));
+                                classPath.getClass(methodLocal.getDefiningClass())));
             } else {
                 setPostRegisterTypeAndPropagateChanges(startOfMethod, thisRegister,
                         RegisterType.getRegisterType(RegisterType.REFERENCE,
-                                classPath.getClass(method.getDefiningClass())));
+                                classPath.getClass(methodLocal.getDefiningClass())));
             }
 
             propagateParameterTypes(totalRegisters-parameterRegisters+1);
@@ -216,7 +216,7 @@ public class MethodAnalyzer {
                         ex.codeAddress = codeAddress;
                         ex.addContext(String.format("opcode: %s", instructionToAnalyze.instruction.getOpcode().name));
                         ex.addContext(String.format("code address: %d", codeAddress));
-                        ex.addContext(String.format("method: %s", ReferenceUtil.getReferenceString(method)));
+                        ex.addContext(String.format("method: %s", ReferenceUtil.getReferenceString(methodLocal)));
                         break;
                     }
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/RegisterType.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/RegisterType.java
@@ -278,12 +278,12 @@ public class RegisterType {
 
         TypeProto mergedType = null;
         if (mergedCategory == REFERENCE) {
-            TypeProto type = this.type;
-            if (type != null) {
+            TypeProto typeLocal = this.type;
+            if (typeLocal != null) {
                 if (other.type != null) {
-                    mergedType = type.getCommonSuperclass(other.type);
+                    mergedType = typeLocal.getCommonSuperclass(other.type);
                 } else {
-                    mergedType = type;
+                    mergedType = typeLocal;
                 }
             } else {
                 mergedType = other.type;

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/ReflectionMethod.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/ReflectionMethod.java
@@ -54,9 +54,9 @@ public class ReflectionMethod extends BaseMethodReference implements Method {
     }
 
     @Nonnull @Override public List<? extends MethodParameter> getParameters() {
-        final java.lang.reflect.Method method = this.method;
+        final java.lang.reflect.Method methodLocal = this.method;
         return new AbstractList<MethodParameter>() {
-            private final Class[] parameters = method.getParameterTypes();
+            private final Class[] parameters = methodLocal.getParameterTypes();
 
             @Override public MethodParameter get(final int index) {
                 return new BaseMethodParameter() {

--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/util/TypeProtoUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/util/TypeProtoUtils.java
@@ -64,13 +64,13 @@ public class TypeProtoUtils {
                     }
 
                     @Override public TypeProto next() {
-                        TypeProto type = this.type;
-                        if (type == null) {
+                        TypeProto typeLocal = this.type;
+                        if (typeLocal == null) {
                             throw new NoSuchElementException();
                         }
 
-                        this.type = getSuperclassAsTypeProto(type);
-                        return type;
+                        this.type = getSuperclassAsTypeProto(typeLocal);
+                        return typeLocal;
                     }
 
                     @Override public void remove() {

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
@@ -111,12 +111,12 @@ public class MethodLocation {
         if (this.debugItems != null || other.labels != null) {
             // We need to keep the debug items in the same order. We add the other debug items to this list, then reassign
             // the list.
-            List<BuilderDebugItem> debugItems = getDebugItems(true);
-            for (BuilderDebugItem debugItem: debugItems) {
+            List<BuilderDebugItem> debugItemsLocal = getDebugItems(true);
+            for (BuilderDebugItem debugItem: debugItemsLocal) {
                 debugItem.location = other;
             }
-            debugItems.addAll(other.getDebugItems(false));
-            other.debugItems = debugItems;
+            debugItemsLocal.addAll(other.getDebugItems(false));
+            other.debugItems = debugItemsLocal;
             this.debugItems = null;
         }
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/BaseDexBuffer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/BaseDexBuffer.java
@@ -48,12 +48,12 @@ public class BaseDexBuffer {
     }
 
     public int readSmallUint(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        int result = (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8) |
-                ((buf[offset+2] & 0xff) << 16) |
-                ((buf[offset+3]) << 24);
+        int result = (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8) |
+                ((bufLocal[offset+2] & 0xff) << 16) |
+                ((bufLocal[offset+3]) << 24);
         if (result < 0) {
             throw new ExceptionWithContext("Encountered small uint that is out of range at offset 0x%x", offset);
         }
@@ -61,12 +61,12 @@ public class BaseDexBuffer {
     }
 
     public int readOptionalUint(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        int result = (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8) |
-                ((buf[offset+2] & 0xff) << 16) |
-                ((buf[offset+3]) << 24);
+        int result = (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8) |
+                ((bufLocal[offset+2] & 0xff) << 16) |
+                ((bufLocal[offset+3]) << 24);
         if (result < -1) {
             throw new ExceptionWithContext("Encountered optional uint that is out of range at offset 0x%x", offset);
         }
@@ -74,10 +74,10 @@ public class BaseDexBuffer {
     }
 
     public int readUshort(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        return (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8);
+        return (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8);
     }
 
     public int readUbyte(int offset) {
@@ -85,29 +85,29 @@ public class BaseDexBuffer {
     }
 
     public long readLong(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        return (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8) |
-                ((buf[offset+2] & 0xff) << 16) |
-                ((buf[offset+3] & 0xffL) << 24) |
-                ((buf[offset+4] & 0xffL) << 32) |
-                ((buf[offset+5] & 0xffL) << 40) |
-                ((buf[offset+6] & 0xffL) << 48) |
-                (((long)buf[offset+7]) << 56);
+        return (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8) |
+                ((bufLocal[offset+2] & 0xff) << 16) |
+                ((bufLocal[offset+3] & 0xffL) << 24) |
+                ((bufLocal[offset+4] & 0xffL) << 32) |
+                ((bufLocal[offset+5] & 0xffL) << 40) |
+                ((bufLocal[offset+6] & 0xffL) << 48) |
+                (((long)bufLocal[offset+7]) << 56);
     }
 
     public int readLongAsSmallUint(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        long result = (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8) |
-                ((buf[offset+2] & 0xff) << 16) |
-                ((buf[offset+3] & 0xffL) << 24) |
-                ((buf[offset+4] & 0xffL) << 32) |
-                ((buf[offset+5] & 0xffL) << 40) |
-                ((buf[offset+6] & 0xffL) << 48) |
-                (((long)buf[offset+7]) << 56);
+        long result = (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8) |
+                ((bufLocal[offset+2] & 0xff) << 16) |
+                ((bufLocal[offset+3] & 0xffL) << 24) |
+                ((bufLocal[offset+4] & 0xffL) << 32) |
+                ((bufLocal[offset+5] & 0xffL) << 40) |
+                ((bufLocal[offset+6] & 0xffL) << 48) |
+                (((long)bufLocal[offset+7]) << 56);
         if (result < 0 || result > Integer.MAX_VALUE) {
             throw new ExceptionWithContext("Encountered out-of-range ulong at offset 0x%x", offset);
         }
@@ -115,19 +115,19 @@ public class BaseDexBuffer {
     }
 
     public int readInt(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        return (buf[offset] & 0xff) |
-                ((buf[offset+1] & 0xff) << 8) |
-                ((buf[offset+2] & 0xff) << 16) |
-                (buf[offset+3] << 24);
+        return (bufLocal[offset] & 0xff) |
+                ((bufLocal[offset+1] & 0xff) << 8) |
+                ((bufLocal[offset+2] & 0xff) << 16) |
+                (bufLocal[offset+3] << 24);
     }
 
     public int readShort(int offset) {
-        byte[] buf = this.buf;
+        byte[] bufLocal = this.buf;
         offset += baseOffset;
-        return (buf[offset] & 0xff) |
-                (buf[offset+1] << 8);
+        return (bufLocal[offset] & 0xff) |
+                (bufLocal[offset+1] << 8);
     }
 
     public int readByte(int offset) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedClassDef.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedClassDef.java
@@ -151,7 +151,7 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
         if (staticFieldCount > 0) {
             DexReader reader = dexFile.readerAt(staticFieldsOffset);
 
-            final AnnotationsDirectory annotationsDirectory = getAnnotationsDirectory();
+            final AnnotationsDirectory annotationsDirectoryLocal = getAnnotationsDirectory();
             final int staticInitialValuesOffset =
                     dexFile.readSmallUint(classDefOffset + ClassDefItem.STATIC_VALUES_OFFSET);
             final int fieldsStartOffset = reader.getOffset();
@@ -161,7 +161,7 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
                 @Override
                 public Iterator<DexBackedField> iterator() {
                     final AnnotationsDirectory.AnnotationIterator annotationIterator =
-                            annotationsDirectory.getFieldAnnotationIterator();
+                            annotationsDirectoryLocal.getFieldAnnotationIterator();
                     final StaticInitialValueIterator staticInitialValueIterator =
                             StaticInitialValueIterator.newOrEmpty(dexFile, staticInitialValuesOffset);
 
@@ -214,7 +214,7 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
         if (instanceFieldCount > 0) {
             DexReader reader = dexFile.readerAt(getInstanceFieldsOffset());
 
-            final AnnotationsDirectory annotationsDirectory = getAnnotationsDirectory();
+            final AnnotationsDirectory annotationsDirectoryLocal = getAnnotationsDirectory();
             final int fieldsStartOffset = reader.getOffset();
 
             return new Iterable<DexBackedField>() {
@@ -222,7 +222,7 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
                 @Override
                 public Iterator<DexBackedField> iterator() {
                     final AnnotationsDirectory.AnnotationIterator annotationIterator =
-                            annotationsDirectory.getFieldAnnotationIterator();
+                            annotationsDirectoryLocal.getFieldAnnotationIterator();
 
                     return new VariableSizeLookaheadIterator<DexBackedField>(dexFile, fieldsStartOffset) {
                         private int count;
@@ -281,7 +281,7 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
         if (directMethodCount > 0) {
             DexReader reader = dexFile.readerAt(getDirectMethodsOffset());
 
-            final AnnotationsDirectory annotationsDirectory = getAnnotationsDirectory();
+            final AnnotationsDirectory annotationsDirectoryLocal = getAnnotationsDirectory();
             final int methodsStartOffset = reader.getOffset();
 
             return new Iterable<DexBackedMethod>() {
@@ -289,9 +289,9 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
                 @Override
                 public Iterator<DexBackedMethod> iterator() {
                     final AnnotationsDirectory.AnnotationIterator methodAnnotationIterator =
-                            annotationsDirectory.getMethodAnnotationIterator();
+                            annotationsDirectoryLocal.getMethodAnnotationIterator();
                     final AnnotationsDirectory.AnnotationIterator parameterAnnotationIterator =
-                            annotationsDirectory.getParameterAnnotationIterator();
+                            annotationsDirectoryLocal.getParameterAnnotationIterator();
 
                     return new VariableSizeLookaheadIterator<DexBackedMethod>(dexFile, methodsStartOffset) {
                         private int count;
@@ -338,14 +338,14 @@ public class DexBackedClassDef extends BaseTypeReference implements ClassDef {
         if (virtualMethodCount > 0) {
             DexReader reader = dexFile.readerAt(getVirtualMethodsOffset());
 
-            final AnnotationsDirectory annotationsDirectory = getAnnotationsDirectory();
+            final AnnotationsDirectory annotationsDirectoryLocal = getAnnotationsDirectory();
             final int methodsStartOffset = reader.getOffset();
 
             return new Iterable<DexBackedMethod>() {
                 final AnnotationsDirectory.AnnotationIterator methodAnnotationIterator =
-                        annotationsDirectory.getMethodAnnotationIterator();
+                        annotationsDirectoryLocal.getMethodAnnotationIterator();
                 final AnnotationsDirectory.AnnotationIterator parameterAnnotationIterator =
-                        annotationsDirectory.getParameterAnnotationIterator();
+                        annotationsDirectoryLocal.getParameterAnnotationIterator();
 
                 @Nonnull
                 @Override

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethod.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethod.java
@@ -122,8 +122,8 @@ public class DexBackedMethod extends BaseMethodReference implements Method {
     @Nonnull
     @Override
     public List<? extends MethodParameter> getParameters() {
-        int parametersOffset = getParametersOffset();
-        if (parametersOffset > 0) {
+        int parametersOffsetLocal = getParametersOffset();
+        if (parametersOffsetLocal > 0) {
             final List<String> parameterTypes = getParameterTypes();
 
             return new AbstractForwardSequentialList<MethodParameter>() {
@@ -158,10 +158,10 @@ public class DexBackedMethod extends BaseMethodReference implements Method {
     @Nonnull
     @Override
     public List<String> getParameterTypes() {
-        final int parametersOffset = getParametersOffset();
-        if (parametersOffset > 0) {
-            final int parameterCount = dexFile.readSmallUint(parametersOffset + TypeListItem.SIZE_OFFSET);
-            final int paramListStart = parametersOffset + TypeListItem.LIST_OFFSET;
+        final int parametersOffsetLocal = getParametersOffset();
+        if (parametersOffsetLocal > 0) {
+            final int parameterCount = dexFile.readSmallUint(parametersOffsetLocal + TypeListItem.SIZE_OFFSET);
+            final int paramListStart = parametersOffsetLocal + TypeListItem.LIST_OFFSET;
             return new FixedSizeList<String>() {
                 @Nonnull
                 @Override

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/OatFile.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/OatFile.java
@@ -81,25 +81,25 @@ public class OatFile extends BaseDexBuffer {
             throw new InvalidOatFileException(String.format("Invalid word-size value: %x", buf[5]));
         }
 
-        OatHeader oatHeader = null;
+        OatHeader oatHeaderLocal = null;
         SymbolTable symbolTable = getSymbolTable();
         for (Symbol symbol: symbolTable.getSymbols()) {
             if (symbol.getName().equals("oatdata")) {
-                oatHeader = new OatHeader(symbol.getFileOffset());
+                oatHeaderLocal = new OatHeader(symbol.getFileOffset());
                 break;
             }
         }
 
-        if (oatHeader == null) {
+        if (oatHeaderLocal == null) {
             throw new InvalidOatFileException("Oat file has no oatdata symbol");
         }
-        this.oatHeader = oatHeader;
+        this.oatHeader = oatHeaderLocal;
 
-        if (!oatHeader.isValid()) {
+        if (!oatHeaderLocal.isValid()) {
             throw new InvalidOatFileException("Invalid oat magic value");
         }
 
-        this.opcodes = Opcodes.forArtVersion(oatHeader.getVersion());
+        this.opcodes = Opcodes.forArtVersion(oatHeaderLocal.getVersion());
     }
 
     private static void verifyMagic(byte[] buf) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/MapItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/MapItem.java
@@ -87,8 +87,8 @@ public class MapItem {
                 int size = dexFile.readSmallUint(out.getCursor());
                 out.annotate(4, "size = %d", size);
 
-                int offset = dexFile.readSmallUint(out.getCursor());
-                out.annotate(4, "offset = 0x%x", offset);
+                int offsetLocal = dexFile.readSmallUint(out.getCursor());
+                out.annotate(4, "offset = 0x%x", offsetLocal);
             }
 
             @Override public void annotateSection(@Nonnull AnnotatedBytes out) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
@@ -67,8 +67,8 @@ public class DexBackedMethodReference extends BaseMethodReference {
     @Nonnull
     @Override
     public List<String> getParameterTypes() {
-        int protoIdItemOffset = getProtoIdItemOffset();
-        final int parametersOffset = dexFile.readSmallUint(protoIdItemOffset + ProtoIdItem.PARAMETERS_OFFSET);
+        int protoIdItemOffsetLocal = getProtoIdItemOffset();
+        final int parametersOffset = dexFile.readSmallUint(protoIdItemOffsetLocal + ProtoIdItem.PARAMETERS_OFFSET);
         if (parametersOffset > 0) {
             final int parameterCount = dexFile.readSmallUint(parametersOffset + TypeListItem.SIZE_OFFSET);
             final int paramListStart = parametersOffset + TypeListItem.LIST_OFFSET;
@@ -87,8 +87,8 @@ public class DexBackedMethodReference extends BaseMethodReference {
     @Nonnull
     @Override
     public String getReturnType() {
-        int protoIdItemOffset = getProtoIdItemOffset();
-        return dexFile.getType(dexFile.readSmallUint(protoIdItemOffset + ProtoIdItem.RETURN_TYPE_OFFSET));
+        int protoIdItemOffsetLocal = getProtoIdItemOffset();
+        return dexFile.getType(dexFile.readSmallUint(protoIdItemOffsetLocal + ProtoIdItem.RETURN_TYPE_OFFSET));
     }
 
     private int getProtoIdItemOffset() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:HiddenFieldCheck - Local variables should not shadow class fields

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck

Please let me know if you have any questions.

M-Ezzat