### PR TITLE
resolvedField is always null

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/MethodAnalyzer.java
@@ -1697,8 +1697,8 @@ public class MethodAnalyzer {
             // actually valid for this class
             resolvedField = classPath.getClass(fieldClass.getType()).getFieldByOffset(fieldOffset);
             if (resolvedField == null) {
-                throw new ExceptionWithContext("Couldn't find accessible class while resolving field %s",
-                        ReferenceUtil.getShortFieldDescriptor(resolvedField));
+                throw new ExceptionWithContext("Couldn't find accessible class while resolving field in class %s at offset %d",
+                        fieldClass.getType(), fieldOffset);
             }
             resolvedField = new ImmutableFieldReference(fieldClass.getType(), resolvedField.getName(),
                     resolvedField.getType());


### PR DESCRIPTION
resolvedField is always null
invoke ReferenceUtil.getShortFieldDescriptor(resolvedField), Throws null pointer exception