### PR TITLE
Fix build error for java 6 and close ".smali" files when finished reading them in for smali

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
@@ -31,6 +31,7 @@
 
 package org.jf.dexlib2.analysis;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -219,7 +220,7 @@ public class ClassProto implements TypeProto {
 
         if (!interfacesFullyResolved) {
             throw new UnresolvedClassException("Interfaces for class %s not fully resolved: %s", getType(),
-                    String.join(",", getUnresolvedInterfaces()));
+                    Joiner.on(',').join(getUnresolvedInterfaces()));
         }
 
         return directInterfaces;

--- a/smali/src/main/java/org/jf/smali/main.java
+++ b/smali/src/main/java/org/jf/smali/main.java
@@ -308,18 +308,15 @@ public class main {
 
     private static boolean assembleSmaliFile(File smaliFile, DexBuilder dexBuilder, SmaliOptions options)
             throws Exception {
-        CommonTokenStream tokens = null;
-        LexerErrorInterface lexer = null;
         FileInputStream fis = null;
-        boolean ret = true;
         
-        try{
+        try {
             fis = new FileInputStream(smaliFile);
             InputStreamReader reader = new InputStreamReader(fis, "UTF-8");
     
-            lexer = new smaliFlexLexer(reader);
+            LexerErrorInterface lexer = new smaliFlexLexer(reader);
             ((smaliFlexLexer)lexer).setSourceFile(smaliFile);
-            tokens = new CommonTokenStream((TokenSource)lexer);
+            CommonTokenStream tokens = new CommonTokenStream((TokenSource)lexer);
     
             if (options.printTokens) {
                 tokens.getTokens();
@@ -362,13 +359,12 @@ public class main {
             dexGen.setVerboseErrors(options.verboseErrors);
             dexGen.setDexBuilder(dexBuilder);
             dexGen.smali_file();
-            ret = dexGen.getNumberOfSyntaxErrors() == 0;
-        }finally{
-            if(fis != null){
+            return dexGen.getNumberOfSyntaxErrors() == 0;
+        } finally {
+            if (fis != null) {
                 fis.close();
             }
         }
-        return ret;
     }
 
 

--- a/smali/src/main/java/org/jf/smali/main.java
+++ b/smali/src/main/java/org/jf/smali/main.java
@@ -308,60 +308,67 @@ public class main {
 
     private static boolean assembleSmaliFile(File smaliFile, DexBuilder dexBuilder, SmaliOptions options)
             throws Exception {
-        CommonTokenStream tokens;
-
-        LexerErrorInterface lexer;
-
-        FileInputStream fis = new FileInputStream(smaliFile);
-        InputStreamReader reader = new InputStreamReader(fis, "UTF-8");
-
-        lexer = new smaliFlexLexer(reader);
-        ((smaliFlexLexer)lexer).setSourceFile(smaliFile);
-        tokens = new CommonTokenStream((TokenSource)lexer);
-
-        if (options.printTokens) {
-            tokens.getTokens();
-
-            for (int i=0; i<tokens.size(); i++) {
-                Token token = tokens.get(i);
-                if (token.getChannel() == smaliParser.HIDDEN) {
-                    continue;
+        CommonTokenStream tokens = null;
+        LexerErrorInterface lexer = null;
+        FileInputStream fis = null;
+        boolean ret = true;
+        
+        try{
+            fis = new FileInputStream(smaliFile);
+            InputStreamReader reader = new InputStreamReader(fis, "UTF-8");
+    
+            lexer = new smaliFlexLexer(reader);
+            ((smaliFlexLexer)lexer).setSourceFile(smaliFile);
+            tokens = new CommonTokenStream((TokenSource)lexer);
+    
+            if (options.printTokens) {
+                tokens.getTokens();
+    
+                for (int i=0; i<tokens.size(); i++) {
+                    Token token = tokens.get(i);
+                    if (token.getChannel() == smaliParser.HIDDEN) {
+                        continue;
+                    }
+    
+                    System.out.println(smaliParser.tokenNames[token.getType()] + ": " + token.getText());
                 }
-
-                System.out.println(smaliParser.tokenNames[token.getType()] + ": " + token.getText());
+    
+                System.out.flush();
             }
-
-            System.out.flush();
+    
+            smaliParser parser = new smaliParser(tokens);
+            parser.setVerboseErrors(options.verboseErrors);
+            parser.setAllowOdex(options.allowOdex);
+            parser.setApiLevel(options.apiLevel, options.experimental);
+    
+            smaliParser.smali_file_return result = parser.smali_file();
+    
+            if (parser.getNumberOfSyntaxErrors() > 0 || lexer.getNumberOfSyntaxErrors() > 0) {
+                return false;
+            }
+    
+            CommonTree t = result.getTree();
+    
+            CommonTreeNodeStream treeStream = new CommonTreeNodeStream(t);
+            treeStream.setTokenStream(tokens);
+    
+            if (options.printTokens) {
+                System.out.println(t.toStringTree());
+            }
+    
+            smaliTreeWalker dexGen = new smaliTreeWalker(treeStream);
+            dexGen.setApiLevel(options.apiLevel, options.experimental);
+    
+            dexGen.setVerboseErrors(options.verboseErrors);
+            dexGen.setDexBuilder(dexBuilder);
+            dexGen.smali_file();
+            ret = dexGen.getNumberOfSyntaxErrors() == 0;
+        }finally{
+            if(fis != null){
+                fis.close();
+            }
         }
-
-        smaliParser parser = new smaliParser(tokens);
-        parser.setVerboseErrors(options.verboseErrors);
-        parser.setAllowOdex(options.allowOdex);
-        parser.setApiLevel(options.apiLevel, options.experimental);
-
-        smaliParser.smali_file_return result = parser.smali_file();
-
-        if (parser.getNumberOfSyntaxErrors() > 0 || lexer.getNumberOfSyntaxErrors() > 0) {
-            return false;
-        }
-
-        CommonTree t = result.getTree();
-
-        CommonTreeNodeStream treeStream = new CommonTreeNodeStream(t);
-        treeStream.setTokenStream(tokens);
-
-        if (options.printTokens) {
-            System.out.println(t.toStringTree());
-        }
-
-        smaliTreeWalker dexGen = new smaliTreeWalker(treeStream);
-        dexGen.setApiLevel(options.apiLevel, options.experimental);
-
-        dexGen.setVerboseErrors(options.verboseErrors);
-        dexGen.setDexBuilder(dexBuilder);
-        dexGen.smali_file();
-
-        return dexGen.getNumberOfSyntaxErrors() == 0;
+        return ret;
     }
 
 


### PR DESCRIPTION
So this contains two changes. The first fixes a build error. You were using the join method introduced in java 8 and trying to build for java 6 which does not compile correctly obviously. I just replaced the join method with a call to Joiner in guava which should have the same effect and since you are already using guava there should be no real changes.

The second deals with the fact that you were not closing the .smali files after you finished parsing them in the smali tool. This is not a big deal when running the tool from main. However, when running it from run it would leave potentially thousands of files open and interfere with operations on those files at a later time. This just simply surrounds the whole parsing procedure with a try finally block that will close the opened file if an error occurs or once the parsing completes successfully.