### PR TITLE
dexlib2: Allow compilation with Java7.

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassProto.java
@@ -293,7 +293,7 @@ public class ClassProto implements TypeProto {
 
         if (!interfacesFullyResolved) {
             throw new UnresolvedClassException("Interfaces for class %s not fully resolved: %s", getType(),
-                    Joiner.on(',').join(getUnresolvedInterfaces()));
+                    getUnresolvedInterfaces());
         }
 
         return directInterfaces;


### PR DESCRIPTION
Unfortunately, some of the ART test servers still compile java
source with JDK7.

Separately, this call to String.join is unnecessary. HashSet.toString
will do the right thing anyway.