### PR TITLE
Add a placeholder ART version number / api level for aosp/master.

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/Opcode.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/Opcode.java
@@ -305,8 +305,8 @@ public enum Opcode
     SPARSE_SWITCH_PAYLOAD(0x200, "sparse-switch-payload", ReferenceType.NONE, Format.SparseSwitchPayload, 0),
     ARRAY_PAYLOAD(0x300, "array-payload", ReferenceType.NONE, Format.ArrayPayload, 0),
 
-    INVOKE_POLYMORPHIC(firstApi(0xfa, 26), "invoke-polymorphic", ReferenceType.METHOD, ReferenceType.METHOD_PROTO, Format.Format45cc, Opcode.CAN_THROW | Opcode.CAN_CONTINUE | Opcode.SETS_RESULT),
-    INVOKE_POLYMORPHIC_RANGE(firstApi(0xfb, 26), "invoke-polymorphic/range", ReferenceType.METHOD, ReferenceType.METHOD_PROTO, Format.Format4rcc, Opcode.CAN_THROW | Opcode.CAN_CONTINUE | Opcode.SETS_RESULT);
+    INVOKE_POLYMORPHIC(firstArtVersion(0xfa, 87), "invoke-polymorphic", ReferenceType.METHOD, ReferenceType.METHOD_PROTO, Format.Format45cc, Opcode.CAN_THROW | Opcode.CAN_CONTINUE | Opcode.SETS_RESULT),
+    INVOKE_POLYMORPHIC_RANGE(firstArtVersion(0xfb, 87), "invoke-polymorphic/range", ReferenceType.METHOD, ReferenceType.METHOD_PROTO, Format.Format4rcc, Opcode.CAN_THROW | Opcode.CAN_CONTINUE | Opcode.SETS_RESULT);
 
     //if the instruction can throw an exception
     public static final int CAN_THROW = 0x1;

--- a/dexlib2/src/main/java/org/jf/dexlib2/Opcodes.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/Opcodes.java
@@ -92,9 +92,9 @@ public class Opcodes {
 
         int version;
         if (isArt()) {
-            version = artVersion;
+            version = this.artVersion;
         } else {
-            version = api;
+            version = this.api;
         }
 
         for (Opcode opcode: Opcode.values()) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/VersionMap.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/VersionMap.java
@@ -35,6 +35,12 @@ public class VersionMap {
     public static final int NO_VERSION = -1;
 
     public static int mapArtVersionToApi(int artVersion) {
+        // NOTE: Art version 87 and api level 26 do not correspond to any
+        // particular android release and represent the current (as of
+        // October 2016) state of aosp/master.
+        if (artVersion >= 87) {
+            return 26;
+        }
         if (artVersion >= 79) {
             return 24;
         }
@@ -62,10 +68,15 @@ public class VersionMap {
             case 23:
                 return 64;
             case 24:
+            case 25:
                 return 79;
         }
-        if (api > 24) {
-            return 79;
+
+        // NOTE: Art version 87 and api level 26 do not correspond to any
+        // particular android release and represent the current (as of
+        // October 2016) state of aosp/master.
+        if (api > 25) {
+            return 87;
         }
         return NO_VERSION;
     }


### PR DESCRIPTION
Also make invoke-polymorphic conditional on this new art version.

This also fixes a bug where the version was being selected incorrectly
due to a parameter name that shadowed a local variable.