### PR TITLE
Fix open file resource leaks

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/ZipDexContainer.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/ZipDexContainer.java
@@ -122,14 +122,18 @@ public class ZipDexContainer implements MultiDexContainer<ZipDexFile> {
         }
     }
 
-    public boolean isZipFile() {
+    public boolean isZipFile() throws IOException {
+    	ZipFile zipFile = null;
         try {
-            getZipFile();
+            zipFile = getZipFile();
             return true;
         } catch (IOException ex) {
             return false;
         } catch (NotAZipFileException ex) {
             return false;
+        } finally {
+        	if(zipFile != null)
+        		zipFile.close();
         }
     }
 


### PR DESCRIPTION
This fixes the open file resource leaks when writing smali files that were fixed previously. This also fixes a resource leak in the isZipFile method of ZipDexContainer. For the second, basically the ZipFile would remain open if it existed but then go immediately out of scope.