### PR TITLE
Add support for getting byte sizes to dex backed references

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -30,8 +30,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 Unless otherwise stated in the code/commit message, any changes with the
-committer of bgruv@google.com is copyrighted by Google Inc. and released
-under the following license:
+committer of bgruv@google.com or wkal@google.com is copyrighted by 
+Google Inc. and released under the following license:
 
 *******************************************************************************
 Copyright 2011, Google Inc.

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
@@ -36,6 +36,7 @@ import org.jf.dexlib2.dexbacked.instruction.DexBackedInstruction;
 import org.jf.dexlib2.dexbacked.raw.CodeItem;
 import org.jf.dexlib2.dexbacked.util.DebugInfo;
 import org.jf.dexlib2.dexbacked.util.FixedSizeList;
+import org.jf.dexlib2.dexbacked.util.VariableSizeListIterator;
 import org.jf.dexlib2.dexbacked.util.VariableSizeLookaheadIterator;
 import org.jf.dexlib2.iface.MethodImplementation;
 import org.jf.dexlib2.iface.debug.DebugItem;
@@ -147,5 +148,32 @@ public class DexBackedMethodImplementation implements MethodImplementation {
     @Nonnull
     public Iterator<String> getParameterNames(@Nullable DexReader dexReader) {
         return getDebugInfo().getParameterNames(dexReader);
+    }
+
+    /**
+     * Calculate and return the private size of a method implementation.
+     *
+     * Calculated as: debug info size + instructions size + try-catch size
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        int debugSize = getDebugInfo().getSize();
+
+        //set code_item ending offset to the end of instructions list (insns_size * ushort)
+        int lastOffset = dexFile.readSmallUint(codeOffset + CodeItem.INSTRUCTION_COUNT_OFFSET) * 2;
+
+        //read any exception handlers and move code_item offset to the end
+        for (DexBackedTryBlock tryBlock: getTryBlocks()) {
+            Iterator<? extends DexBackedExceptionHandler> tryHandlerIter =
+                tryBlock.getExceptionHandlers().iterator();
+            while (tryHandlerIter.hasNext()) {
+                tryHandlerIter.next();
+            }
+            lastOffset = ((VariableSizeListIterator)tryHandlerIter).getReaderOffset();
+        }
+
+        //method impl size = debug block size + code_item size
+        return debugSize + (lastOffset - codeOffset);
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedFieldReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedFieldReference.java
@@ -63,4 +63,15 @@ public class DexBackedFieldReference extends BaseFieldReference {
     public String getType() {
         return dexFile.getType(dexFile.readUshort(fieldIdItemOffset + FieldIdItem.TYPE_OFFSET));
     }
+
+    /**
+     * Calculate and return the private size of a field reference.
+     *
+     * Calculated as: class_idx + type_idx + name_idx
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        return FieldIdItem.ITEM_SIZE;
+    }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodProtoReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodProtoReference.java
@@ -74,4 +74,20 @@ public class DexBackedMethodProtoReference extends BaseMethodProtoReference {
     public String getReturnType() {
         return dexFile.getType(dexFile.readSmallUint(protoIdItemOffset + ProtoIdItem.RETURN_TYPE_OFFSET));
     }
+
+    /**
+     * Calculate and return the private size of a method proto.
+     *
+     * Calculated as: shorty_idx + return_type_idx + parameters_off + type_list size
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        int size = ProtoIdItem.ITEM_SIZE; //3 * uint
+        List<String> parameters = getParameterTypes();
+        if (!parameters.isEmpty()) {
+            size += 4 + parameters.size() * 2; //uint + size * ushort for type_idxs
+        }
+        return size;
+    }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
@@ -98,4 +98,19 @@ public class DexBackedMethodReference extends BaseMethodReference {
         }
         return protoIdItemOffset;
     }
+
+    /**
+     * Calculate and return the private size of a method reference.
+     *
+     * Calculated as: class_idx + proto_idx + name_idx + prototype size
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        int size = MethodIdItem.ITEM_SIZE; //ushort + ushort + uint for indices
+        DexBackedMethodProtoReference protoRef = new DexBackedMethodProtoReference(dexFile,
+            dexFile.readUshort(methodIdItemOffset + MethodIdItem.PROTO_OFFSET));
+        size += protoRef.getSize();
+        return size;
+    }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedStringReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedStringReference.java
@@ -33,6 +33,8 @@ package org.jf.dexlib2.dexbacked.reference;
 
 import org.jf.dexlib2.base.reference.BaseStringReference;
 import org.jf.dexlib2.dexbacked.DexBackedDexFile;
+import org.jf.dexlib2.dexbacked.DexReader;
+import org.jf.dexlib2.dexbacked.raw.StringIdItem;
 
 import javax.annotation.Nonnull;
 
@@ -49,5 +51,26 @@ public class DexBackedStringReference extends BaseStringReference {
     @Nonnull
     public String getString() {
         return dexFile.getString(stringIndex);
+    }
+
+
+    /**
+     * Calculate and return the private size of a string reference.
+     *
+     * Calculated as: string_data_off + string_data_item size
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        int size = StringIdItem.ITEM_SIZE; //uint for string_data_off
+        //add the string data length:
+        int stringOffset = dexFile.getStringIdItemOffset(stringIndex);
+        int stringDataOffset = dexFile.readSmallUint(stringOffset);
+        DexReader reader = dexFile.readerAt(stringDataOffset);
+        size += reader.peekSmallUleb128Size();
+        int utf16Length = reader.readSmallUleb128();
+        //and string data itself:
+        size += reader.peekStringLength(utf16Length);
+        return size;
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedTypeReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedTypeReference.java
@@ -33,6 +33,7 @@ package org.jf.dexlib2.dexbacked.reference;
 
 import org.jf.dexlib2.base.reference.BaseTypeReference;
 import org.jf.dexlib2.dexbacked.DexBackedDexFile;
+import org.jf.dexlib2.dexbacked.raw.TypeIdItem;
 
 import javax.annotation.Nonnull;
 
@@ -48,5 +49,17 @@ public class DexBackedTypeReference extends BaseTypeReference {
 
     @Nonnull public String getType() {
         return dexFile.getType(typeIndex);
+    }
+
+
+    /**
+     * Calculate and return the private size of a type reference.
+     *
+     * Calculated as: descriptor_idx
+     *
+     * @return size in bytes
+     */
+    public int getSize() {
+        return TypeIdItem.ITEM_SIZE; //uint for descriptor_idx
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/DebugInfo.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/DebugInfo.java
@@ -59,6 +59,13 @@ public abstract class DebugInfo implements Iterable<DebugItem> {
      */
     @Nonnull public abstract Iterator<String> getParameterNames(@Nullable DexReader reader);
 
+    /**
+     * Calculate and return the private size of debuginfo.
+     *
+     * @return size in bytes
+     */
+    public abstract int getSize();
+
     public static DebugInfo newOrEmpty(@Nonnull DexBackedDexFile dexFile, int debugInfoOffset,
                                        @Nonnull DexBackedMethodImplementation methodImpl) {
         if (debugInfoOffset == 0) {
@@ -77,6 +84,11 @@ public abstract class DebugInfo implements Iterable<DebugItem> {
 
         @Nonnull @Override public Iterator<String> getParameterNames(@Nullable DexReader reader) {
             return ImmutableSet.<String>of().iterator();
+        }
+
+        @Override
+        public int getSize() {
+            return 0;
         }
     }
 
@@ -278,6 +290,15 @@ public abstract class DebugInfo implements Iterable<DebugItem> {
                     return dexFile.getOptionalString(reader.readSmallUleb128() - 1);
                 }
             };
+        }
+
+        @Override
+        public int getSize() {
+            Iterator<DebugItem> iter = iterator();
+            while(iter.hasNext()) {
+                iter.next();
+            }
+            return ((VariableSizeLookaheadIterator) iter).getReaderOffset() - debugInfoOffset;
         }
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/StaticInitialValueIterator.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/StaticInitialValueIterator.java
@@ -43,10 +43,12 @@ public abstract class StaticInitialValueIterator {
     public static final StaticInitialValueIterator EMPTY = new StaticInitialValueIterator() {
         @Nullable @Override public EncodedValue getNextOrNull() { return null; }
         @Override public void skipNext() {}
+        @Override public int getReaderOffset() { return 0; }
     };
 
     @Nullable public abstract EncodedValue getNextOrNull();
     public abstract void skipNext();
+    public abstract int getReaderOffset();
 
     @Nonnull
     public static StaticInitialValueIterator newOrEmpty(@Nonnull DexBackedDexFile dexFile, int offset) {
@@ -80,6 +82,10 @@ public abstract class StaticInitialValueIterator {
                 index++;
                 DexBackedEncodedValue.skipFrom(reader);
             }
+        }
+
+        public int getReaderOffset() {
+            return reader.getOffset();
         }
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/VariableSizeLookaheadIterator.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/util/VariableSizeLookaheadIterator.java
@@ -59,4 +59,8 @@ public abstract class VariableSizeLookaheadIterator<T> extends AbstractIterator<
     protected T computeNext() {
         return readNextItem(reader);
     }
+
+    public final int getReaderOffset() {
+        return reader.getOffset();
+    }
 }

--- a/dexlib2/src/test/java/org/jf/dexlib2/dexbacked/BaseDexReaderLeb128Test.java
+++ b/dexlib2/src/test/java/org/jf/dexlib2/dexbacked/BaseDexReaderLeb128Test.java
@@ -254,11 +254,21 @@ public class BaseDexReaderLeb128Test {
         reader = dexBuf.readerAt(0);
         reader.skipUleb128();
         Assert.assertEquals(expectedLength, reader.getOffset());
+
+        reader = dexBuf.readerAt(0);
+        Assert.assertEquals(expectedLength, reader.peekSmallUleb128Size());
     }
 
     private void performFailureTest(byte[] buf) {
         BaseDexBuffer dexBuf = new BaseDexBuffer(buf);
         BaseDexReader reader = dexBuf.readerAt(0);
+        try {
+            reader.peekSmallUleb128Size();
+            Assert.fail();
+        } catch (ExceptionWithContext ex) {
+            // expected exception
+        }
+
         try {
             reader.readSmallUleb128();
             Assert.fail();

--- a/dexlib2/src/test/java/org/jf/dexlib2/dexbacked/BaseDexReaderSleb128Test.java
+++ b/dexlib2/src/test/java/org/jf/dexlib2/dexbacked/BaseDexReaderSleb128Test.java
@@ -257,11 +257,20 @@ public class BaseDexReaderSleb128Test {
         BaseDexReader reader = dexBuf.readerAt(0);
         Assert.assertEquals(expectedValue, reader.readSleb128());
         Assert.assertEquals(expectedLength, reader.getOffset());
+
+        reader = dexBuf.readerAt(0);
+        Assert.assertEquals(expectedLength, reader.peekSleb128Size());
     }
 
     private void performFailureTest(byte[] buf) {
         BaseDexBuffer dexBuf = new BaseDexBuffer(buf);
         BaseDexReader reader = dexBuf.readerAt(0);
+        try {
+            reader.peekSleb128Size();
+            Assert.fail();
+        } catch (ExceptionWithContext ex) {
+            // expected exception
+        }
         try {
             reader.readSleb128();
             Assert.fail();

--- a/smalidea/build.gradle
+++ b/smalidea/build.gradle
@@ -49,7 +49,7 @@ apply plugin: 'idea'
 apply plugin: 'antlr'
 
 
-version = '0.04'
+version = '0.05'
 
 if (!('release' in gradle.startParameter.taskNames)) {
     def versionSuffix

--- a/smalidea/src/main/java/org/jf/smalidea/dexlib/instruction/SmalideaPackedSwitchPayload.java
+++ b/smalidea/src/main/java/org/jf/smalidea/dexlib/instruction/SmalideaPackedSwitchPayload.java
@@ -86,7 +86,7 @@ public class SmalideaPackedSwitchPayload extends SmalideaInstruction implements 
                         return 0;
                     }
 
-                    return label.getOffset() - baseOffset;
+                    return (label.getOffset() - baseOffset) / 2;
                 }
             });
         }

--- a/smalidea/src/main/java/org/jf/smalidea/dexlib/instruction/SmalideaSparseSwitchPayload.java
+++ b/smalidea/src/main/java/org/jf/smalidea/dexlib/instruction/SmalideaSparseSwitchPayload.java
@@ -79,7 +79,7 @@ public class SmalideaSparseSwitchPayload extends SmalideaInstruction implements 
                             return 0;
                         }
 
-                        return label.getOffset() - baseOffset;
+                        return (label.getOffset() - baseOffset) / 2;
                     }
                 };
             }


### PR DESCRIPTION
We discussed this briefly over email, this adds basic support for reading byte sizes of code inside dex files.