### PR TITLE
adding odex version 100, as used in Sony A7S II (and other) cameras

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/InlineMethodResolver.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/InlineMethodResolver.java
@@ -55,6 +55,8 @@ public abstract class InlineMethodResolver {
             return new InlineMethodResolver_version35();
         } else if (odexVersion == 36) {
             return new InlineMethodResolver_version36();
+	} else if (odexVersion == 100) {
+            return new InlineMethodResolver_version36();
         } else {
             throw new RuntimeException(String.format("odex version %d is not supported yet", odexVersion));
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/OdexHeaderItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/raw/OdexHeaderItem.java
@@ -37,7 +37,7 @@ public class OdexHeaderItem {
     public static final int ITEM_SIZE = 40;
 
     private static final byte[] MAGIC_VALUE = new byte[] { 0x64, 0x65, 0x79, 0x0A, 0x00, 0x00, 0x00, 0x00 };
-    private static final int[] SUPPORTED_ODEX_VERSIONS = new int[] { 35, 36 };
+    private static final int[] SUPPORTED_ODEX_VERSIONS = new int[] { 35, 36, 100 };
 
     public static final int MAGIC_OFFSET = 0;
     public static final int MAGIC_LENGTH = 8;


### PR DESCRIPTION
Sony cameras with android support (A7* for sure, most likely NEX, etc) set the ODEX version number to be 100 (31,30,30).  Just adding an entry for 100 pointing to the 36 settings seems to convert them just fine.