### PR TITLE
hardcode File.pathSeparatorChar into semicolon

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassPathResolver.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/ClassPathResolver.java
@@ -195,7 +195,7 @@ public class ClassPathResolver {
         // It's not a local path, so let's try to resolve it as a device path, relative to one of the provided
         // directories
         List<String> pathComponents = splitDevicePath(entry);
-        Joiner pathJoiner = Joiner.on(File.pathSeparatorChar);
+        Joiner pathJoiner = Joiner.on(";");
 
         for (String directory: classPathDirs) {
             File directoryFile = new File(directory);


### PR DESCRIPTION
On Windows the `File.pathSeparatorChar` returns `:` character. By separating the paths with this char we break all full paths in this form:
> C:\path\to\my\folder

(with drive letter and `:` char at the beginning) leading it to throw NotFoundException, thus not finding bootclasspath.

Fix by hardcoding it into a semicolon, this won't conflict on any system.