### PR TITLE
Fix out registers for invoke-polymorphic

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/util/InstructionUtil.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/util/InstructionUtil.java
@@ -38,5 +38,9 @@ public final class InstructionUtil {
         return opcode == Opcode.INVOKE_STATIC || opcode == Opcode.INVOKE_STATIC_RANGE;
     }
 
+    public static boolean isInvokePolymorphic(Opcode opcode) {
+        return opcode == Opcode.INVOKE_POLYMORPHIC || opcode == Opcode.INVOKE_POLYMORPHIC_RANGE;
+    }
+
     private InstructionUtil() {}
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
@@ -52,6 +52,7 @@ import org.jf.dexlib2.iface.debug.LineNumber;
 import org.jf.dexlib2.iface.instruction.Instruction;
 import org.jf.dexlib2.iface.instruction.OneRegisterInstruction;
 import org.jf.dexlib2.iface.instruction.ReferenceInstruction;
+import org.jf.dexlib2.iface.instruction.VariableRegisterInstruction;
 import org.jf.dexlib2.iface.instruction.formats.*;
 import org.jf.dexlib2.iface.reference.*;
 import org.jf.dexlib2.util.InstructionUtil;
@@ -955,7 +956,13 @@ public abstract class DexWriter<
                 if (instruction.getOpcode().referenceType == ReferenceType.METHOD) {
                     ReferenceInstruction refInsn = (ReferenceInstruction)instruction;
                     MethodReference methodRef = (MethodReference)refInsn.getReference();
-                    int paramCount = MethodUtil.getParameterRegisterCount(methodRef, InstructionUtil.isInvokeStatic(instruction.getOpcode()));
+                    Opcode opcode = instruction.getOpcode();
+                    int paramCount;
+                    if (InstructionUtil.isInvokePolymorphic(opcode)) {
+                        paramCount = ((VariableRegisterInstruction)instruction).getRegisterCount();
+                    } else {
+                        paramCount = MethodUtil.getParameterRegisterCount(methodRef, InstructionUtil.isInvokeStatic(opcode));
+                    }
                     if (paramCount > outParamCount) {
                         outParamCount = paramCount;
                     }


### PR DESCRIPTION
The calculation of the number of output registers for
invoke-polymorphic and invoke-polymorphic-range should be based on the
number of registers provided.

Review at:
 https://android-review.googlesource.com/c/platform/external/smali/+/456058