### PR TITLE
Fix for method reference sizes

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/reference/DexBackedMethodReference.java
@@ -102,15 +102,11 @@ public class DexBackedMethodReference extends BaseMethodReference {
     /**
      * Calculate and return the private size of a method reference.
      *
-     * Calculated as: class_idx + proto_idx + name_idx + prototype size
+     * Calculated as: class_idx + proto_idx + name_idx
      *
      * @return size in bytes
      */
     public int getSize() {
-        int size = MethodIdItem.ITEM_SIZE; //ushort + ushort + uint for indices
-        DexBackedMethodProtoReference protoRef = new DexBackedMethodProtoReference(dexFile,
-            dexFile.readUshort(methodIdItemOffset + MethodIdItem.PROTO_OFFSET));
-        size += protoRef.getSize();
-        return size;
+        return MethodIdItem.ITEM_SIZE; //ushort + ushort + uint for indices
     }
 }


### PR DESCRIPTION
Protos can be shared across methods so we should not be counting them as part of private method size.