### PR TITLE
Fix NaN comparison

### DIFF
--- a/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItem.java
+++ b/baksmali/src/main/java/org/jf/baksmali/Adaptors/Format/InstructionMethodItem.java
@@ -501,7 +501,7 @@ public class InstructionMethodItem<T extends Instruction> extends MethodItem {
                 writer.write("Float.POSITIVE_INFINITY");
             else if (fval == Float.NEGATIVE_INFINITY)
                 writer.write("Float.NEGATIVE_INFINITY");
-            else if (fval == Float.NaN)
+            else if (Float.isNaN(fval))
                 writer.write("Float.NaN");
             else if (fval == Float.MAX_VALUE)
                 writer.write("Float.MAX_VALUE");
@@ -528,7 +528,7 @@ public class InstructionMethodItem<T extends Instruction> extends MethodItem {
                 writer.write("Double.POSITIVE_INFINITY");
             else if (dval == Double.NEGATIVE_INFINITY)
                 writer.write("Double.NEGATIVE_INFINITY");
-            else if (dval == Double.NaN)
+            else if (Double.isNaN(dval))
                 writer.write("Double.NaN");
             else if (dval == Double.MAX_VALUE)
                 writer.write("Double.MAX_VALUE");


### PR DESCRIPTION
Use Float.isNaN/Double.isNaN to correctly detect NaN.

Detected by errorprone.