### PR TITLE
Fix and extend hasOverflowed

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
@@ -107,6 +107,8 @@ public abstract class DexWriter<
     public static final int NO_INDEX = -1;
     public static final int NO_OFFSET = 0;
 
+    public static final int MAX_POOL_SIZE = (1 << 16);
+
     protected final Opcodes opcodes;
 
     protected int stringIndexSectionOffset = NO_OFFSET;
@@ -150,6 +152,8 @@ public abstract class DexWriter<
     public final AnnotationSetSectionType annotationSetSection;
     public final EncodedArraySectionType encodedArraySection;
 
+    private final IndexSection<?>[] overflowableSections;
+
     protected DexWriter(Opcodes opcodes) {
         this.opcodes = opcodes;
 
@@ -166,6 +170,17 @@ public abstract class DexWriter<
         this.annotationSection = sectionProvider.getAnnotationSection();
         this.annotationSetSection = sectionProvider.getAnnotationSetSection();
         this.encodedArraySection = sectionProvider.getEncodedArraySection();
+
+        overflowableSections = new IndexSection<?>[] {
+                //stringSection,            // supports jumbo indexes
+                typeSection,
+                protoSection,
+                fieldSection,
+                methodSection,
+                //classSection,             // redundant check: cannot be larger than typeSection
+                callSiteSection,
+                methodHandleSection,
+        };
     }
 
     @Nonnull protected abstract SectionProvider getSectionProvider();
@@ -250,19 +265,28 @@ public abstract class DexWriter<
     }
 
     /**
-     * Checks whether any of the size-sensitive constant pools have overflowed.
-     *
-     * This checks whether the type, method, field pools are larger than 64k entries.
+     * Checks whether any of the size-sensitive constant pools have overflowed and have more than 64Ki entries.
      *
      * Note that even if this returns true, it may still be possible to successfully write the dex file, if the
-     * overflowed items are not referenced anywhere that uses a 16-bit index
+     * overflowed items are not referenced anywhere that uses a 16-bit index.
      *
      * @return true if any of the size-sensitive constant pools have overflowed
      */
     public boolean hasOverflowed() {
-        return methodSection.getItemCount() > (1 << 16) ||
-                typeSection.getItemCount() > (1 << 16) ||
-                fieldSection.getItemCount() > (1 << 16);
+        return hasOverflowed(MAX_POOL_SIZE);
+    }
+
+    /**
+     * Checks whether any of the size-sensitive constant pools have more than the supplied maximum number of entries.
+     *
+     * @param maxPoolSize the maximum number of entries allowed in any of the size-sensitive constant pools
+     * @return true if any of the size-sensitive constant pools have overflowed the supplied size limit
+     */
+    public boolean hasOverflowed(int maxPoolSize) {
+        for (IndexSection section: overflowableSections) {
+            if (section.getItemCount() > maxPoolSize) return true;
+        }
+        return false;
     }
 
     public void writeTo(@Nonnull DexDataStore dest) throws IOException {

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
@@ -138,6 +138,10 @@ public abstract class DexWriter<
     protected int numCodeItemItems = 0;
     protected int numClassDataItems = 0;
 
+    // The sections defined here must be kept in sync with these section arrays:
+    // - DexWriter.overflowableSections
+    // - DexPool.sections
+
     public final StringSectionType stringSection;
     public final TypeSectionType typeSection;
     public final ProtoSectionType protoSection;

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/DexPool.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/DexPool.java
@@ -57,9 +57,20 @@ public class DexPool extends DexWriter<CharSequence, StringReference, CharSequen
         ArrayEncodedValue, EncodedValue, AnnotationElement, StringPool, TypePool, ProtoPool, FieldPool, MethodPool,
         ClassPool, CallSitePool, MethodHandlePool, TypeListPool, AnnotationPool, AnnotationSetPool, EncodedArrayPool> {
 
-    private final Markable[] sections = new Markable[] {
-            stringSection, typeSection, protoSection, fieldSection, methodSection, classSection, callSiteSection,
-            methodHandleSection, typeListSection, annotationSection, annotationSetSection, encodedArraySection
+    private final BasePool<?, ?>[] sections = new BasePool<?, ?>[] {
+            stringSection,
+            typeSection,
+            protoSection,
+            fieldSection,
+            methodSection,
+            classSection,
+            callSiteSection,
+            methodHandleSection,
+
+            typeListSection,
+            annotationSection,
+            annotationSetSection,
+            encodedArraySection,
     };
 
     public DexPool(Opcodes opcodes) {


### PR DESCRIPTION
please do include `hasOverflowed(int maxPoolSize)`. it is vital to test multidex tools, to benchmark multidex processing, to generate multidex APKs for research goals, and to provide users of tools with multidex processing samples. here is a [real-wrold use case](https://github.com/DexPatcher/dexpatcher-gradle-samples/blob/d0a610cf550994bfd790d0989efd0f08a55747e2/multi-dex/patched/build.gradle#L37-L61).