### PR TITLE
Refactor - Remove duplicated code from MethodLocation

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/BuilderDebugItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/BuilderDebugItem.java
@@ -35,8 +35,8 @@ import org.jf.dexlib2.iface.debug.DebugItem;
 
 import javax.annotation.Nullable;
 
-public abstract class BuilderDebugItem implements DebugItem {
-    @Nullable MethodLocation location;
+public abstract class BuilderDebugItem extends ItemWithLocation implements DebugItem{
+
 
     public BuilderDebugItem() {
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/BuilderDebugItem.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/BuilderDebugItem.java
@@ -33,9 +33,7 @@ package org.jf.dexlib2.builder;
 
 import org.jf.dexlib2.iface.debug.DebugItem;
 
-import javax.annotation.Nullable;
-
-public abstract class BuilderDebugItem extends ItemWithLocation implements DebugItem{
+public abstract class BuilderDebugItem extends ItemWithLocation implements DebugItem {
 
 
     public BuilderDebugItem() {

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/ItemWithLocation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/ItemWithLocation.java
@@ -1,0 +1,16 @@
+package org.jf.dexlib2.builder;
+
+import javax.annotation.Nullable;
+
+public abstract class ItemWithLocation {
+    @Nullable
+    MethodLocation location;
+
+    public boolean isPlaced() {
+        return location != null;
+    }
+
+    public void setLocation(MethodLocation methodLocation) {
+        location = methodLocation;
+    }
+}

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/Label.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/Label.java
@@ -32,12 +32,9 @@
 package org.jf.dexlib2.builder;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-public class Label {
-    @Nullable MethodLocation location;
-
-    Label() {
+public class Label extends ItemWithLocation {
+    Label(){
     }
 
     Label(MethodLocation location) {
@@ -54,9 +51,5 @@ public class Label {
             throw new IllegalStateException("Cannot get the location of a label that hasn't been placed yet.");
         }
         return location;
-    }
-
-    public boolean isPlaced() {
-        return location != null;
     }
 }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/Label.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/Label.java
@@ -34,7 +34,7 @@ package org.jf.dexlib2.builder;
 import javax.annotation.Nonnull;
 
 public class Label extends ItemWithLocation {
-    Label(){
+    Label() {
     }
 
     Label(MethodLocation location) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedDebugItems.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedDebugItems.java
@@ -3,7 +3,7 @@ package org.jf.dexlib2.builder;
 public class LocatedDebugItems extends LocatedItems<BuilderDebugItem> {
 
     @Override
-    protected String addLocatedItemError() {
+    protected String getAddLocatedItemError() {
         return "Cannot add a debug item that has already been added to a method." +
                 "You must remove it from its current location first.";
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedDebugItems.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedDebugItems.java
@@ -1,0 +1,10 @@
+package org.jf.dexlib2.builder;
+
+public class LocatedDebugItems extends LocatedItems<BuilderDebugItem> {
+
+    @Override
+    protected String addLocatedItemError() {
+        return "Cannot add a debug item that has already been added to a method." +
+                "You must remove it from its current location first.";
+    }
+}

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
@@ -10,12 +10,6 @@ public abstract class LocatedItems<T extends ItemWithLocation> {
     @Nullable
     private List<T> items = null;
 
-    private void initItemsIfNull() {
-        if (items == null) {
-            items = new ArrayList<>(1);
-        }
-    }
-
     @Nonnull
     private List<T> getItems() {
         if (items == null) {
@@ -67,17 +61,23 @@ public abstract class LocatedItems<T extends ItemWithLocation> {
                     throw new IllegalArgumentException(getAddLocatedItemError());
                 }
                 item.setLocation(newItemsLocation);
-                initItemsIfNull();
-                items.add(item);
+                addItem(item);
                 return true;
             }
         };
     }
 
+    private void addItem(@Nonnull T item) {
+        if (items == null) {
+            items = new ArrayList<>(1);
+        }
+        items.add(item);
+    }
+
     protected abstract String getAddLocatedItemError();
 
     public void mergeItemsIntoNext(@Nonnull MethodLocation nextLocation, LocatedItems<T> otherLocatedItems) {
-        if(otherLocatedItems == this){
+        if (otherLocatedItems == this) {
             return;
         }
         if (items != null) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
@@ -10,44 +10,44 @@ public abstract class LocatedItems<T extends ItemWithLocation> {
     @Nullable
     private List<T> items = null;
 
-    @Nonnull
-    private List<T> getMutableItems() {
+    private void initItemsIfNull() {
         if (items == null) {
             items = new ArrayList<>(1);
         }
-        return items;
     }
 
     @Nonnull
-    private List<T> getImmutableItems() {
+    private List<T> getItems() {
         if (items == null) {
             return ImmutableList.of();
         }
         return items;
     }
 
-
-
     public Set<T> getModifiableItems(MethodLocation newItemsLocation) {
         return new AbstractSet<T>() {
             @Nonnull
-            @Override public Iterator<T> iterator() {
-                final Iterator<T> it = getImmutableItems().iterator();
+            @Override
+            public Iterator<T> iterator() {
+                final Iterator<T> it = getItems().iterator();
 
                 return new Iterator<T>() {
                     private @Nullable
                     T currentItem = null;
 
-                    @Override public boolean hasNext() {
+                    @Override
+                    public boolean hasNext() {
                         return it.hasNext();
                     }
 
-                    @Override public T next() {
+                    @Override
+                    public T next() {
                         currentItem = it.next();
                         return currentItem;
                     }
 
-                    @Override public void remove() {
+                    @Override
+                    public void remove() {
                         if (currentItem != null) {
                             currentItem.setLocation(null);
                         }
@@ -56,32 +56,37 @@ public abstract class LocatedItems<T extends ItemWithLocation> {
                 };
             }
 
-            @Override public int size() {
-                return getImmutableItems().size();
+            @Override
+            public int size() {
+                return getItems().size();
             }
 
-            @Override public boolean add(@Nonnull T item) {
+            @Override
+            public boolean add(@Nonnull T item) {
                 if (item.isPlaced()) {
-
-
-                    throw new IllegalArgumentException(addLocatedItemError());
+                    throw new IllegalArgumentException(getAddLocatedItemError());
                 }
                 item.setLocation(newItemsLocation);
-                getMutableItems().add(item);
+                initItemsIfNull();
+                items.add(item);
                 return true;
             }
         };
     }
 
-    protected abstract String addLocatedItemError();
+    protected abstract String getAddLocatedItemError();
 
-    public void mergeItemsInto(@Nonnull MethodLocation newLocation, LocatedItems<T> otherLocatedItems) {
-        if (items != null || otherLocatedItems.items != null) {
-            List<T> otherItems = otherLocatedItems.getMutableItems();
-            for (T item: getImmutableItems()) {
-                item.setLocation(newLocation);
-                otherItems.add(item);
+    public void mergeItemsIntoNext(@Nonnull MethodLocation nextLocation, LocatedItems<T> otherLocatedItems) {
+        if(otherLocatedItems == this){
+            return;
+        }
+        if (items != null) {
+            for (T item : items) {
+                item.setLocation(nextLocation);
             }
+            List<T> mergedItems = items;
+            mergedItems.addAll(otherLocatedItems.getItems());
+            otherLocatedItems.items = mergedItems;
             items = null;
         }
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedItems.java
@@ -1,0 +1,89 @@
+package org.jf.dexlib2.builder;
+
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.*;
+
+public abstract class LocatedItems<T extends ItemWithLocation> {
+    @Nullable
+    private List<T> items = null;
+
+    @Nonnull
+    private List<T> getMutableItems() {
+        if (items == null) {
+            items = new ArrayList<>(1);
+        }
+        return items;
+    }
+
+    @Nonnull
+    private List<T> getImmutableItems() {
+        if (items == null) {
+            return ImmutableList.of();
+        }
+        return items;
+    }
+
+
+
+    public Set<T> getModifiableItems(MethodLocation newItemsLocation) {
+        return new AbstractSet<T>() {
+            @Nonnull
+            @Override public Iterator<T> iterator() {
+                final Iterator<T> it = getImmutableItems().iterator();
+
+                return new Iterator<T>() {
+                    private @Nullable
+                    T currentItem = null;
+
+                    @Override public boolean hasNext() {
+                        return it.hasNext();
+                    }
+
+                    @Override public T next() {
+                        currentItem = it.next();
+                        return currentItem;
+                    }
+
+                    @Override public void remove() {
+                        if (currentItem != null) {
+                            currentItem.setLocation(null);
+                        }
+                        it.remove();
+                    }
+                };
+            }
+
+            @Override public int size() {
+                return getImmutableItems().size();
+            }
+
+            @Override public boolean add(@Nonnull T item) {
+                if (item.isPlaced()) {
+
+
+                    throw new IllegalArgumentException(addLocatedItemError());
+                }
+                item.setLocation(newItemsLocation);
+                getMutableItems().add(item);
+                return true;
+            }
+        };
+    }
+
+    protected abstract String addLocatedItemError();
+
+    public void mergeItemsInto(@Nonnull MethodLocation newLocation, LocatedItems<T> otherLocatedItems) {
+        if (items != null || otherLocatedItems.items != null) {
+            List<T> otherItems = otherLocatedItems.getMutableItems();
+            for (T item: getImmutableItems()) {
+                item.setLocation(newLocation);
+                otherItems.add(item);
+            }
+            items = null;
+        }
+    }
+
+}

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedLabels.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedLabels.java
@@ -1,0 +1,9 @@
+package org.jf.dexlib2.builder;
+
+public class LocatedLabels extends LocatedItems<Label> {
+    @Override
+    protected String addLocatedItemError() {
+        return "Cannot add a label that is already placed." +
+                "You must remove it from its current location first.";
+    }
+}

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedLabels.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/LocatedLabels.java
@@ -2,7 +2,7 @@ package org.jf.dexlib2.builder;
 
 public class LocatedLabels extends LocatedItems<Label> {
     @Override
-    protected String addLocatedItemError() {
+    protected String getAddLocatedItemError() {
         return "Cannot add a label that is already placed." +
                 "You must remove it from its current location first.";
     }

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
@@ -31,7 +31,6 @@
 
 package org.jf.dexlib2.builder;
 
-import com.google.common.collect.ImmutableList;
 import org.jf.dexlib2.builder.debug.*;
 import org.jf.dexlib2.iface.instruction.Instruction;
 import org.jf.dexlib2.iface.reference.StringReference;
@@ -49,13 +48,13 @@ public class MethodLocation {
     // We end up creating and keeping around a *lot* of MethodLocation objects
     // when building a new dex file, so it's worth the trouble of lazily creating
     // the labels and debugItems lists only when they are needed
-
+    private final LocatedItems<Label> labels;
     @Nullable
-    private List<Label> labels = null;
-    @Nullable
-    private List<BuilderDebugItem> debugItems = null;
+    private final LocatedItems<BuilderDebugItem> debugItems;
 
     MethodLocation(@Nullable BuilderInstruction instruction, int codeAddress, int index) {
+        this.debugItems = new LocatedDebugItems();
+        this.labels = new LocatedLabels();
         this.instruction = instruction;
         this.codeAddress = codeAddress;
         this.index = index;
@@ -74,167 +73,28 @@ public class MethodLocation {
         return index;
     }
 
-    @Nonnull
-    private List<Label> getMutableLabels() {
-        if (labels == null) {
-            labels = new ArrayList<>(1);
-        }
-        return labels;
-    }
-    
-    @Nonnull
-    private List<Label> getImmutableLabels() {
-        if (labels == null) {
-            return ImmutableList.of();
-        }
-        return labels;
-    }
-
-
-    @Nonnull
-    private List<BuilderDebugItem> getMutableDebugItems() {
-        if (debugItems == null) {
-            debugItems = new ArrayList<>(1);
-        }
-        return debugItems;
-    }
-
-    @Nonnull
-    private List<BuilderDebugItem> getImmutableDebugItems() {
-        if (debugItems == null) {
-            return ImmutableList.of();
-        }
-        return debugItems;
-    }
-
-    @Nonnull
-    private List<BuilderDebugItem> getDebugItems(boolean mutable) {
-        if (debugItems == null) {
-            if (mutable) {
-                debugItems = new ArrayList<>(1);
-                return debugItems;
-            }
-            return ImmutableList.of();
-        }
-        return debugItems;
-    }
-
     void mergeInto(@Nonnull MethodLocation other) {
-        if (this.labels != null || other.labels != null) {
-            List<Label> otherLabels = other.getMutableLabels();
-            for (Label label: this.getImmutableLabels()) {
-                label.location = other;
-                otherLabels.add(label);
-            }
-            this.labels = null;
-        }
+        labels.mergeItemsInto(other, other.labels);
 
-        if (this.debugItems != null || other.labels != null) {
-            // We need to keep the debug items in the same order. We add the other debug items to this list, then reassign
-            // the list.
-            List<BuilderDebugItem> debugItems = getMutableDebugItems();
-            for (BuilderDebugItem debugItem: debugItems) {
-                debugItem.location = other;
-            }
-            debugItems.addAll(other.getImmutableDebugItems());
-            other.debugItems = debugItems;
-            this.debugItems = null;
-        }
+        debugItems.mergeItemsInto(other, other.debugItems);
     }
 
     @Nonnull
     public Set<Label> getLabels() {
-        return new AbstractSet<Label>() {
-            @Nonnull
-            @Override public Iterator<Label> iterator() {
-                final Iterator<Label> it = getImmutableLabels().iterator();
-
-                return new Iterator<Label>() {
-                    private @Nullable Label currentLabel = null;
-
-                    @Override public boolean hasNext() {
-                        return it.hasNext();
-                    }
-
-                    @Override public Label next() {
-                        currentLabel = it.next();
-                        return currentLabel;
-                    }
-
-                    @Override public void remove() {
-                        if (currentLabel != null) {
-                            currentLabel.location = null;
-                        }
-                        it.remove();
-                    }
-                };
-            }
-
-            @Override public int size() {
-                return getImmutableLabels().size();
-            }
-
-            @Override public boolean add(@Nonnull Label label) {
-                if (label.isPlaced()) {
-                    throw new IllegalArgumentException("Cannot add a label that is already placed. You must remove " +
-                            "it from its current location first.");
-                }
-                label.location = MethodLocation.this;
-                getMutableLabels().add(label);
-                return true;
-            }
-        };
+        return labels.getModifiableItems(MethodLocation.this);
     }
 
     @Nonnull
     public Label addNewLabel() {
-        Label label = new Label(this);
-        getMutableLabels().add(label);
-        return label;
+        Label newLabel = new Label();
+        getLabels().add(newLabel);
+        return newLabel;
     }
+
 
     @Nonnull
     public Set<BuilderDebugItem> getDebugItems() {
-        return new AbstractSet<BuilderDebugItem>() {
-            @Nonnull
-            @Override public Iterator<BuilderDebugItem> iterator() {
-                final Iterator<BuilderDebugItem> it = getImmutableDebugItems().iterator();
-
-                return new Iterator<BuilderDebugItem>() {
-                    private @Nullable BuilderDebugItem currentDebugItem = null;
-
-                    @Override public boolean hasNext() {
-                        return it.hasNext();
-                    }
-
-                    @Override public BuilderDebugItem next() {
-                        currentDebugItem = it.next();
-                        return currentDebugItem;
-                    }
-
-                    @Override public void remove() {
-                        if (currentDebugItem != null) {
-                            currentDebugItem.location = null;
-                        }
-                        it.remove();
-                    }
-                };
-            }
-
-            @Override public int size() {
-                return getImmutableDebugItems().size();
-            }
-
-            @Override public boolean add(@Nonnull BuilderDebugItem debugItem) {
-                if (debugItem.location != null) {
-                    throw new IllegalArgumentException("Cannot add a debug item that has already been added to a " +
-                            "method. You must remove it from its current location first.");
-                }
-                debugItem.location = MethodLocation.this;
-                getMutableDebugItems().add(debugItem);
-                return true;
-            }
-        };
+        return debugItems.getModifiableItems(MethodLocation.this);
     }
 
     public void addLineNumber(int lineNumber) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
@@ -49,7 +49,6 @@ public class MethodLocation {
     // when building a new dex file, so it's worth the trouble of lazily creating
     // the labels and debugItems lists only when they are needed
     private final LocatedItems<Label> labels;
-    @Nullable
     private final LocatedItems<BuilderDebugItem> debugItems;
 
     MethodLocation(@Nullable BuilderInstruction instruction, int codeAddress, int index) {
@@ -73,10 +72,9 @@ public class MethodLocation {
         return index;
     }
 
-    void mergeInto(@Nonnull MethodLocation other) {
-        labels.mergeItemsInto(other, other.labels);
-
-        debugItems.mergeItemsInto(other, other.debugItems);
+    void mergeInto(@Nonnull MethodLocation nextLocation) {
+        labels.mergeItemsIntoNext(nextLocation, nextLocation.labels);
+        debugItems.mergeItemsIntoNext(nextLocation, nextLocation.debugItems);
     }
 
     @Nonnull

--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java
@@ -75,22 +75,43 @@ public class MethodLocation {
     }
 
     @Nonnull
-    private List<Label> getLabels(boolean mutable) {
+    private List<Label> getMutableLabels() {
         if (labels == null) {
-            if (mutable) {
-                labels = new ArrayList<Label>(1);
-                return labels;
-            }
+            labels = new ArrayList<>(1);
+        }
+        return labels;
+    }
+    
+    @Nonnull
+    private List<Label> getImmutableLabels() {
+        if (labels == null) {
             return ImmutableList.of();
         }
         return labels;
+    }
+
+
+    @Nonnull
+    private List<BuilderDebugItem> getMutableDebugItems() {
+        if (debugItems == null) {
+            debugItems = new ArrayList<>(1);
+        }
+        return debugItems;
+    }
+
+    @Nonnull
+    private List<BuilderDebugItem> getImmutableDebugItems() {
+        if (debugItems == null) {
+            return ImmutableList.of();
+        }
+        return debugItems;
     }
 
     @Nonnull
     private List<BuilderDebugItem> getDebugItems(boolean mutable) {
         if (debugItems == null) {
             if (mutable) {
-                debugItems = new ArrayList<BuilderDebugItem>(1);
+                debugItems = new ArrayList<>(1);
                 return debugItems;
             }
             return ImmutableList.of();
@@ -100,8 +121,8 @@ public class MethodLocation {
 
     void mergeInto(@Nonnull MethodLocation other) {
         if (this.labels != null || other.labels != null) {
-            List<Label> otherLabels = other.getLabels(true);
-            for (Label label: this.getLabels(false)) {
+            List<Label> otherLabels = other.getMutableLabels();
+            for (Label label: this.getImmutableLabels()) {
                 label.location = other;
                 otherLabels.add(label);
             }
@@ -111,11 +132,11 @@ public class MethodLocation {
         if (this.debugItems != null || other.labels != null) {
             // We need to keep the debug items in the same order. We add the other debug items to this list, then reassign
             // the list.
-            List<BuilderDebugItem> debugItems = getDebugItems(true);
+            List<BuilderDebugItem> debugItems = getMutableDebugItems();
             for (BuilderDebugItem debugItem: debugItems) {
                 debugItem.location = other;
             }
-            debugItems.addAll(other.getDebugItems(false));
+            debugItems.addAll(other.getImmutableDebugItems());
             other.debugItems = debugItems;
             this.debugItems = null;
         }
@@ -126,7 +147,7 @@ public class MethodLocation {
         return new AbstractSet<Label>() {
             @Nonnull
             @Override public Iterator<Label> iterator() {
-                final Iterator<Label> it = getLabels(false).iterator();
+                final Iterator<Label> it = getImmutableLabels().iterator();
 
                 return new Iterator<Label>() {
                     private @Nullable Label currentLabel = null;
@@ -150,7 +171,7 @@ public class MethodLocation {
             }
 
             @Override public int size() {
-                return getLabels(false).size();
+                return getImmutableLabels().size();
             }
 
             @Override public boolean add(@Nonnull Label label) {
@@ -159,7 +180,7 @@ public class MethodLocation {
                             "it from its current location first.");
                 }
                 label.location = MethodLocation.this;
-                getLabels(true).add(label);
+                getMutableLabels().add(label);
                 return true;
             }
         };
@@ -168,7 +189,7 @@ public class MethodLocation {
     @Nonnull
     public Label addNewLabel() {
         Label label = new Label(this);
-        getLabels(true).add(label);
+        getMutableLabels().add(label);
         return label;
     }
 
@@ -177,7 +198,7 @@ public class MethodLocation {
         return new AbstractSet<BuilderDebugItem>() {
             @Nonnull
             @Override public Iterator<BuilderDebugItem> iterator() {
-                final Iterator<BuilderDebugItem> it = getDebugItems(false).iterator();
+                final Iterator<BuilderDebugItem> it = getImmutableDebugItems().iterator();
 
                 return new Iterator<BuilderDebugItem>() {
                     private @Nullable BuilderDebugItem currentDebugItem = null;
@@ -201,7 +222,7 @@ public class MethodLocation {
             }
 
             @Override public int size() {
-                return getDebugItems(false).size();
+                return getImmutableDebugItems().size();
             }
 
             @Override public boolean add(@Nonnull BuilderDebugItem debugItem) {
@@ -210,7 +231,7 @@ public class MethodLocation {
                             "method. You must remove it from its current location first.");
                 }
                 debugItem.location = MethodLocation.this;
-                getDebugItems(true).add(debugItem);
+                getMutableDebugItems().add(debugItem);
                 return true;
             }
         };

--- a/dexlib2/src/test/java/org/jf/dexlib2/builder/LocatedItemsTest.java
+++ b/dexlib2/src/test/java/org/jf/dexlib2/builder/LocatedItemsTest.java
@@ -1,0 +1,46 @@
+package org.jf.dexlib2.builder;
+
+import com.google.common.collect.Sets;
+import org.jf.dexlib2.builder.debug.BuilderLineNumber;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LocatedItemsTest {
+
+    private List<BuilderDebugItem> createItems(int count){
+        List<BuilderDebugItem> items = new ArrayList<>();
+        for(int i = 0; i < count; ++i){
+            items.add(new BuilderLineNumber(i));
+        }
+        return items;
+    }
+
+    private void doTestMergeIntoKeepsOrderOfDebugItems(int countLocation1, int countLocation2){
+        MethodLocation location1 = new MethodLocation(null, 123, 1);
+        MethodLocation location2 = new MethodLocation(null, 456, 2);
+
+        List<BuilderDebugItem> items1 = createItems(countLocation1);
+        List<BuilderDebugItem> items2 = createItems(countLocation2);
+        location1.getDebugItems().addAll(items1);
+        location2.getDebugItems().addAll(items2);
+
+        location1.mergeInto(location2);
+
+        Assert.assertEquals(Sets.newHashSet(), location1.getDebugItems());
+        // items1 appear BEFORE items2
+        List<BuilderDebugItem> expectedItems = new ArrayList<>(items1);
+        expectedItems.addAll(items2);
+        Assert.assertEquals(expectedItems, new ArrayList<>(location2.getDebugItems()));
+    }
+
+    @Test
+    public void testMergeIntoKeepsOrderOfDebugItems() {
+        doTestMergeIntoKeepsOrderOfDebugItems(2, 2);
+        doTestMergeIntoKeepsOrderOfDebugItems(0, 0);
+        doTestMergeIntoKeepsOrderOfDebugItems(0, 2);
+        doTestMergeIntoKeepsOrderOfDebugItems(2, 0);
+    }
+}

--- a/dexlib2/src/test/java/org/jf/dexlib2/builder/LocatedItemsTest.java
+++ b/dexlib2/src/test/java/org/jf/dexlib2/builder/LocatedItemsTest.java
@@ -10,15 +10,15 @@ import java.util.List;
 
 public class LocatedItemsTest {
 
-    private List<BuilderDebugItem> createItems(int count){
+    private List<BuilderDebugItem> createItems(int count) {
         List<BuilderDebugItem> items = new ArrayList<>();
-        for(int i = 0; i < count; ++i){
+        for (int i = 0; i < count; ++i) {
             items.add(new BuilderLineNumber(i));
         }
         return items;
     }
 
-    private void doTestMergeIntoKeepsOrderOfDebugItems(int countLocation1, int countLocation2){
+    private void doTestMergeIntoKeepsOrderOfDebugItems(int countLocation1, int countLocation2) {
         MethodLocation location1 = new MethodLocation(null, 123, 1);
         MethodLocation location2 = new MethodLocation(null, 456, 2);
 


### PR DESCRIPTION
In order to remove the duplicate code from `MethodLocation`,
which treated labels and debug items very similarly, applied the following steps:

- Have `BuilderDebugItem` and `Label` extend a common abstract class `ItemWithLocation`
- Extract the duplicated code from `MethodLocation` into a new class `LocatedItems<T>`

Additionally, fixed a bug in `MethodLocation::mergeInto()` -
https://github.com/JesusFreke/smali/blob/7079014a29869e1bac22226681de3471b6dc11b5/dexlib2/src/main/java/org/jf/dexlib2/builder/MethodLocation.java#L111
it should have been `other.debugItems` and not `other.labels`

