### PR TITLE
Fix instructions 45cc and 4rcc (invoke-polymorphic)

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/instruction/DexBackedInstruction45cc.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/instruction/DexBackedInstruction45cc.java
@@ -91,7 +91,7 @@ public class DexBackedInstruction45cc extends DexBackedInstruction implements In
     @Override
     public Reference getReference2() {
         return DexBackedReference.makeReference(dexFile, opcode.referenceType2,
-                dexFile.readUshort(instructionStart + 3));
+                dexFile.readUshort(instructionStart + 6));
     }
 
     @Override

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/instruction/DexBackedInstruction4rcc.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/instruction/DexBackedInstruction4rcc.java
@@ -70,7 +70,7 @@ public class DexBackedInstruction4rcc extends DexBackedInstruction implements In
     @Override
     public Reference getReference2() {
         return DexBackedReference.makeReference(dexFile, opcode.referenceType2,
-                dexFile.readUshort(instructionStart + 3));
+                dexFile.readUshort(instructionStart + 6));
     }
 
     @Override


### PR DESCRIPTION
Previously the offset of the method prototype was 3 bytes from the
instruction start for both instructions. This would put it somewhere in
the middle of the register values and method reference. Changed it to
the correct offset which is 6 bytes in both cases.

45cc Instruction Format
  op(8 bits)
  number_of_regs(4 bits)
  reg_g(4 bits)
  method_reference(16 bits)
  reg_d(4 bits)
  reg_c(4 bits)
  reg_f(4 bits)
  ref_e(4 bits)
  method_prototype(16 bits)

Example of invoke-polymorphic using 45cc
  Instruction: fa302f0021030800
  DexDump: invoke-polymorphic  {v1, v2, v3}, Ljava/lang/invoke/MethodHandle;
           .invoke:([Ljava/lang/Object;)Ljava/lang/Object;,
           (II)Ljava/lang/Object; // method@002f, proto@0008

4rcc Instruction Format
  op(8 bits)
  number_of_regs(8 bits)
  method_reference(16 bits)
  start_register(16 bits)
  method_prototype(16 bits)

Example of invoke-polymorphic using 4rcc
  Instruction: fb092f0000000800
  DexDump: invoke-polymorphic/range  {v0, v1, v2, v3, v4, v5, v6, v7, v8},
           Ljava/lang/invoke/MethodHandle;.invoke:([Ljava/lang/Object;)
           Ljava/lang/Object;, (IIIIIIILjava/lang/String;)Ljava/lang/Object;
           // method@002f, proto@0008