### PR TITLE
Align smallidea tokens and grammar on smali

### DIFF
--- a/smalidea/src/main/antlr/smalideaParser.g
+++ b/smalidea/src/main/antlr/smalideaParser.g
@@ -400,6 +400,7 @@ simple_name
   | INSTRUCTION_FORMAT31t
   | INSTRUCTION_FORMAT35c_METHOD
   | INSTRUCTION_FORMAT35c_METHOD_ODEX
+  | INSTRUCTION_FORMAT35c_METHOD_OR_METHOD_HANDLE_TYPE
   | INSTRUCTION_FORMAT35c_TYPE
   | INSTRUCTION_FORMAT35mi_METHOD
   | INSTRUCTION_FORMAT35ms_METHOD
@@ -1253,7 +1254,7 @@ insn_format32x
 
 insn_format35c_method
   : //e.g. invoke-virtual {v0,v1} java/io/PrintStream/print(Ljava/lang/Stream;)V
-    INSTRUCTION_FORMAT35c_METHOD register_list comma fully_qualified_method;
+    (INSTRUCTION_FORMAT35c_METHOD | INSTRUCTION_FORMAT35c_METHOD_OR_METHOD_HANDLE_TYPE) register_list comma fully_qualified_method;
 
 insn_format35c_type
   : //e.g. filled-new-array {v0,v1}, I

--- a/smalidea/src/main/java/org/jf/smalidea/SmaliTokens.java
+++ b/smalidea/src/main/java/org/jf/smalidea/SmaliTokens.java
@@ -120,6 +120,7 @@ public class SmaliTokens {
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT32x;
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35c_METHOD;
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35c_METHOD_ODEX;
+    @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35c_METHOD_OR_METHOD_HANDLE_TYPE;
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35c_TYPE;
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35mi_METHOD;
     @SuppressWarnings({"UnusedDeclaration"}) public static IElementType INSTRUCTION_FORMAT35ms_METHOD;
@@ -238,6 +239,7 @@ public class SmaliTokens {
         tokenColors.put("INSTRUCTION_FORMAT32x", SmaliHighlightingColors.INSTRUCTION);
         tokenColors.put("INSTRUCTION_FORMAT35c_METHOD", SmaliHighlightingColors.INSTRUCTION);
         tokenColors.put("INSTRUCTION_FORMAT35c_METHOD_ODEX", SmaliHighlightingColors.INSTRUCTION);
+        tokenColors.put("INSTRUCTION_FORMAT35c_METHOD_OR_METHOD_HANDLE_TYPE", SmaliHighlightingColors.INSTRUCTION);
         tokenColors.put("INSTRUCTION_FORMAT35c_TYPE", SmaliHighlightingColors.INSTRUCTION);
         tokenColors.put("INSTRUCTION_FORMAT35mi_METHOD", SmaliHighlightingColors.INSTRUCTION);
         tokenColors.put("INSTRUCTION_FORMAT35ms_METHOD", SmaliHighlightingColors.INSTRUCTION);
@@ -343,6 +345,7 @@ public class SmaliTokens {
                 INSTRUCTION_FORMAT32x,
                 INSTRUCTION_FORMAT35c_METHOD,
                 INSTRUCTION_FORMAT35c_METHOD_ODEX,
+                INSTRUCTION_FORMAT35c_METHOD_OR_METHOD_HANDLE_TYPE,
                 INSTRUCTION_FORMAT35c_TYPE,
                 INSTRUCTION_FORMAT35mi_METHOD,
                 INSTRUCTION_FORMAT35ms_METHOD,


### PR DESCRIPTION
- Now the following tests are fixed:
 * org.jf.smalidea.MethodRenameTest.testMethodRename
 * org.jf.smalidea.dexlib.SmalideaMethodTest.testArrayData
 * org.jf.smalidea.dexlib.SmalideaMethodTest.testCatchBlocks
 * org.jf.smalidea.MethodReferenceTest.testJavaReferenceFromSmali
 * org.jf.smalidea.MethodReferenceTest.testSmaliReferenceFromSmali
 * org.jf.smalidea.SmaliCodeFragmentFactoryTest.testUnknownClass
 * org.jf.smalidea.SmaliCodeFragmentFactoryTest.testRegisterType
 * org.jf.smalidea.findUsages.MethodUsageTypeTest.testMethodUsageTypes
 * org.jf.smalidea.findUsages.HighlightLocalClassUsagesTest.testHighlightLocalClassUsage
 * org.jf.smalidea.findUsages.FindClassUsagesTest.testSmaliUsageInSmaliFile
 * org.jf.smalidea.findUsages.FindClassUsagesTest.testJavaUsageInSmaliFile