### PR TITLE
Remove usage of sput-object-volatile into FieldUsageTypeTest

### DIFF
--- a/smalidea/src/test/java/org/jf/smalidea/findUsages/FieldUsageTypeTest.java
+++ b/smalidea/src/test/java/org/jf/smalidea/findUsages/FieldUsageTypeTest.java
@@ -58,7 +58,9 @@ public class FieldUsageTypeTest extends UsageTypeTest {
                         "    sput-byte v0, Lblah;->bl<ref:35>ah:Lblah;\n" +
                         "    sput-char v0, Lblah;->bl<ref:36>ah:Lblah;\n" +
                         "    sput-object v0, Lblah;->bl<ref:37>ah:Lblah;\n" +
-                        "    sput-object-volatile v0, Lblah;->bl<ref:38>ah:Lblah;\n" +
+                        // TODO: sput object volatile is no longer supported at default api level,
+                        // thus disable his usage until Smalidea supports to define an api level
+                        // "    sput-object-volatile v0, Lblah;->bl<ref:38>ah:Lblah;\n" +
                         "    sput-short v0, Lblah;->bl<ref:39>ah:Lblah;\n" +
                         "    sput-volatile v0, Lblah;->bl<ref:40>ah:Lblah;\n" +
                         "    sput-wide v0, Lblah;->bl<ref:41>ah:Lblah;\n" +
@@ -105,7 +107,9 @@ public class FieldUsageTypeTest extends UsageTypeTest {
                 35, UsageType.WRITE,
                 36, UsageType.WRITE,
                 37, UsageType.WRITE,
-                38, UsageType.WRITE,
+                // TODO: sput object volatile is no longer supported at default api level,
+                // thus disable his usage until Smalidea supports to define an api level
+                //38, UsageType.WRITE,
                 39, UsageType.WRITE,
                 40, UsageType.WRITE,
                 41, UsageType.WRITE,


### PR DESCRIPTION
- Since https://github.com/JesusFreke/smali/commit/2db1dec70385eedddd613ea7b426b8516973b5f9, sput-object-volatile is no longer supported at default api level.
Thus remove his usage until Smalidea has a way to define the api level to use.