### PR TITLE
make opcodes nullable in loadDexContainer

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/DexFileFactory.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/DexFileFactory.java
@@ -230,7 +230,7 @@ public final class DexFileFactory {
      * @throws UnsupportedFileTypeException If the given file is not a valid dex/zip/odex/oat file
      */
     public static MultiDexContainer<? extends DexBackedDexFile> loadDexContainer(
-            @Nonnull File file, @Nonnull final Opcodes opcodes) throws IOException {
+            @Nonnull File file, @Nullable final Opcodes opcodes) throws IOException {
         if (!file.exists()) {
             throw new DexFileNotFoundException("%s does not exist", file.getName());
         }


### PR DESCRIPTION
To allow dexlib infer the api level whenever possible this patch changed some code parts:
https://github.com/JesusFreke/smali/commit/077c5c1b91e27c537f7a92be05e693514cedf126

But it seems that the loadDexContainer method was left out (by mistake?). It still requires opcodes to be non-null which is inconsistent to the other methods. This PR fixes it.