### PR TITLE
Fix Register Precondition-check in BuilderInstruction45cc

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/builder/instruction/BuilderInstruction45cc.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/builder/instruction/BuilderInstruction45cc.java
@@ -63,7 +63,7 @@ public class BuilderInstruction45cc extends BuilderInstruction implements Instru
                                   @Nonnull Reference reference2) {
         super(opcode);
         this.registerCount = Preconditions.check35cAnd45ccRegisterCount(registerCount);
-        this.registerC = (registerCount>0) ? Preconditions.checkNibbleRegister(registerC) : 0;
+        this.registerC = (registerCount>0) ? Preconditions.checkShortRegister(registerC) : 0;
         this.registerD = (registerCount>1) ? Preconditions.checkNibbleRegister(registerD) : 0;
         this.registerE = (registerCount>2) ? Preconditions.checkNibbleRegister(registerE) : 0;
         this.registerF = (registerCount>3) ? Preconditions.checkNibbleRegister(registerF) : 0;


### PR DESCRIPTION
According to the [dex specification](https://source.android.com/devices/tech/dalvik/dalvik-bytecode), the instruction 45cc takes 5 registers.

Registers D, E, F, G are of 4-bit size and Register C is of 16-bit size. The BuilderInstruction45cc expected Register C to be of 4-bit size.

Please correct me if I've somehow misinterpreted the specification.