### PR TITLE
fix: Cast java.nio.ByteBuffer to support java6-8

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java
@@ -69,6 +69,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.MessageDigest;
@@ -916,7 +917,7 @@ public abstract class DexWriter<
                 tempBuffer.order(ByteOrder.LITTLE_ENDIAN);
             }
 
-            tempBuffer.clear();
+            ((Buffer) tempBuffer).clear();
 
             int fieldAnnotations = 0;
             int methodAnnotations = 0;


### PR DESCRIPTION
I was having build issues with Apktool, this resolves it. Strangely, I can build smali without this either way without an issue. So its very possible this is entirely my fault somehow.

Though, I found this https://jira.mongodb.org/browse/JAVA-2559 & https://github.com/mongodb/mongo-java-driver/commit/21c91bd364d38489e0bbe2e390efdb3746ee3fff

So I feel less crazy.

Checked entire project.
```
➜  smali git:(master) ✗ grep -r '.position();' * 
➜  smali git:(master) ✗ grep -r '.limit();' *   
➜  smali git:(master) ✗ grep -r '.flip();' *    
➜  smali git:(master) ✗ grep -r '.clear();' *   
dexlib2/src/main/java/org/jf/dexlib2/writer/io/MemoryDeferredOutputStream.java:        buffers.clear();
dexlib2/src/main/java/org/jf/dexlib2/writer/DexWriter.java:            tempBuffer.clear();
➜  smali git:(master) ✗ 
```

Only 1 ByteBuffer affected method used.