### PR TITLE
Avoid exceptions to increase performance

### DIFF
--- a/dexlib2/src/main/java/org/jf/util/CollectionUtils.java
+++ b/dexlib2/src/main/java/org/jf/util/CollectionUtils.java
@@ -78,8 +78,8 @@ public class CollectionUtils {
         Iterator<? extends T> elements2 = it2.iterator();
         for (T element1: it1) {
             T element2;
-          	if (!elements2.hasNext())
-           		return 1;
+            if (!elements2.hasNext())
+                return 1;
             element2 = elements2.next();
             int res = comparator.compare(element1, element2);
             if (res != 0) return res;
@@ -95,8 +95,8 @@ public class CollectionUtils {
         Iterator<? extends T> elements2 = it2.iterator();
         for (T element1: it1) {
             T element2;
-          	if (!elements2.hasNext())
-           		return 1;
+            if (!elements2.hasNext())
+                return 1;
             element2 = elements2.next();
             int res = element1.compareTo(element2);
             if (res != 0) return res;

--- a/dexlib2/src/main/java/org/jf/util/CollectionUtils.java
+++ b/dexlib2/src/main/java/org/jf/util/CollectionUtils.java
@@ -78,11 +78,9 @@ public class CollectionUtils {
         Iterator<? extends T> elements2 = it2.iterator();
         for (T element1: it1) {
             T element2;
-            try {
-                element2 = elements2.next();
-            } catch (NoSuchElementException ex) {
-                return 1;
-            }
+          	if (!elements2.hasNext())
+           		return 1;
+            element2 = elements2.next();
             int res = comparator.compare(element1, element2);
             if (res != 0) return res;
         }
@@ -97,11 +95,9 @@ public class CollectionUtils {
         Iterator<? extends T> elements2 = it2.iterator();
         for (T element1: it1) {
             T element2;
-            try {
-                element2 = elements2.next();
-            } catch (NoSuchElementException ex) {
-                return 1;
-            }
+          	if (!elements2.hasNext())
+           		return 1;
+            element2 = elements2.next();
             int res = element1.compareTo(element2);
             if (res != 0) return res;
         }


### PR DESCRIPTION
The collection utils used to call ``next()`` on an iterator and catch the exception in case there is no next element. This is not optimal, because exceptions are notoriously slow in Java, mainly due to stack trace building. Instead, we should call ``hasNext()``.