### PR TITLE
Add support for Android 12

### DIFF
--- a/baksmali/src/test/java/org/jf/baksmali/HiddenApiRestrictionsRoundtripTest.java
+++ b/baksmali/src/test/java/org/jf/baksmali/HiddenApiRestrictionsRoundtripTest.java
@@ -37,7 +37,7 @@ public class HiddenApiRestrictionsRoundtripTest extends RoundtripTest {
     @Test
     public void testHiddenApiRestrictions() {
         BaksmaliOptions options = new BaksmaliOptions();
-        options.apiLevel = 29;
+        options.apiLevel = 31;
         runTest("HiddenApiRestrictions", options);
     }
 }

--- a/baksmali/src/test/resources/HiddenApiRestrictionsRoundtripTest/HiddenApiRestrictionsInput.smali
+++ b/baksmali/src/test/resources/HiddenApiRestrictionsRoundtripTest/HiddenApiRestrictionsInput.smali
@@ -39,3 +39,18 @@
     return-void
 .end method
 
+.method greylist-max-r private core-platform-api corePlatformApiAndHiddenApiTestR()V
+    .registers 1
+    return-void
+.end method
+
+.method greylist-max-r private test-api testApiMethodR()V
+    .registers 1
+    return-void
+.end method
+
+.method greylist-max-r private test-api core-platform-api testAndCorePlatformApiMethodR()V
+    .registers 1
+    return-void
+.end method
+

--- a/baksmali/src/test/resources/HiddenApiRestrictionsRoundtripTest/HiddenApiRestrictionsOutput.smali
+++ b/baksmali/src/test/resources/HiddenApiRestrictionsRoundtripTest/HiddenApiRestrictionsOutput.smali
@@ -21,6 +21,12 @@
     return-void
 .end method
 
+.method private greylist-max-r core-platform-api corePlatformApiAndHiddenApiTestR()V
+    .registers 1
+
+    return-void
+.end method
+
 .method private whitelist core-platform-api corePlatformApiTest()V
     .registers 1
 
@@ -38,7 +44,17 @@
     return-void
 .end method
 
+.method private greylist-max-r core-platform-api test-api testAndCorePlatformApiMethodR()V
+    .registers 1
+    return-void
+.end method
+
 .method private greylist-max-q test-api testApiMethod()V
+    .registers 1
+    return-void
+.end method
+
+.method private greylist-max-r test-api testApiMethodR()V
     .registers 1
     return-void
 .end method

--- a/dexlib2/src/main/java/org/jf/dexlib2/HiddenApiRestriction.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/HiddenApiRestriction.java
@@ -46,6 +46,7 @@ public enum HiddenApiRestriction {
     GREYLIST_MAX_O(3, "greylist-max-o", false),
     GREYLIST_MAX_P(4, "greylist-max-p", false),
     GREYLIST_MAX_Q(5, "greylist-max-q", false),
+    GREYLIST_MAX_R(6, "greylist-max-r", false),
     CORE_PLATFORM_API(8, "core-platform-api", true),
     TEST_API(16, "test-api", true);
 
@@ -55,7 +56,8 @@ public enum HiddenApiRestriction {
             BLACKLIST,
             GREYLIST_MAX_O,
             GREYLIST_MAX_P,
-            GREYLIST_MAX_Q
+            GREYLIST_MAX_Q,
+            GREYLIST_MAX_R
     };
 
     private static final HiddenApiRestriction[] domainSpecificApiFlags = new HiddenApiRestriction[] {

--- a/smali/src/main/jflex/smaliLexer.jflex
+++ b/smali/src/main/jflex/smaliLexer.jflex
@@ -480,7 +480,7 @@ Type = {PrimitiveType} | {ClassDescriptor} | {ArrayPrefix} ({ClassDescriptor} | 
     }
 
     "whitelist" | "greylist" | "blacklist" | "greylist-max-o" | "greylist-max-p" | "greylist-max-q" |
-    "core-platform-api" | "test-api" {
+    "greylist-max-r" | "core-platform-api" | "test-api" {
         return newToken(HIDDENAPI_RESTRICTION);
     }
 

--- a/smali/src/test/resources/LexerTest/MiscTest.smali
+++ b/smali/src/test/resources/LexerTest/MiscTest.smali
@@ -40,6 +40,7 @@ blacklist
 greylist-max-o
 greylist-max-p
 greylist-max-q
+greylist-max-r
 core-platform-api
 test-api
 

--- a/smali/src/test/resources/LexerTest/MiscTest.tokens
+++ b/smali/src/test/resources/LexerTest/MiscTest.tokens
@@ -40,6 +40,7 @@ HIDDENAPI_RESTRICTION("blacklist")
 HIDDENAPI_RESTRICTION("greylist-max-o")
 HIDDENAPI_RESTRICTION("greylist-max-p")
 HIDDENAPI_RESTRICTION("greylist-max-q")
+HIDDENAPI_RESTRICTION("greylist-max-r")
 HIDDENAPI_RESTRICTION("core-platform-api")
 HIDDENAPI_RESTRICTION("test-api")
 


### PR DESCRIPTION
I saw some issues when decompiling framework.jar of Android 12 Beta 5 by using Apktool. Checked [Android docs](https://developer.android.com/about/versions/12/non-sdk-12) and Google says "greylist-max-r" added to source code. Forked this repo and just added this flag then recompiled apktool. Jar file decompiled successfully.

Error before patch: [framework.jar.log](https://github.com/JesusFreke/smali/files/7173395/framework.jar.log)
After patch: [AFTER-framework.jar.log](https://github.com/JesusFreke/smali/files/7173403/AFTER-framework.jar.log)
