### PR TITLE
Fix dexToJavaName() returning invalid name

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/util/ReflectionUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/analysis/reflection/util/ReflectionUtils.java
@@ -68,6 +68,6 @@ public class ReflectionUtils {
             return primitiveMap.inverse().get(dexName);
         }
 
-        return dexName.replace('/', '.').substring(1, dexName.length()-2);
+        return dexName.replace('/', '.').substring(1, dexName.length()-1);
     }
 }


### PR DESCRIPTION
`ReflectionUtils.dexToJavaName()` was returning an invalid name due to incorrect truncation.

Affected method
- `ReflectionUtils.dexToJavaName()`

