### PR TITLE
Changes related to shared debug info

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/CDexBackedMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/CDexBackedMethodImplementation.java
@@ -75,7 +75,7 @@ public class CDexBackedMethodImplementation extends DexBackedMethodImplementatio
     }
 
     @Override
-    protected int getInstructionsSize() {
+    public int getInstructionsSize() {
         int instructionsSize = dexFile.getDataBuffer().readUshort(
                 codeOffset + CDEX_INSTRUCTIONS_SIZE_AND_PREHEADER_FLAGS_OFFSET) >>
                 CDEX_INSTRUCTIONS_SIZE_SHIFT;

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
@@ -66,7 +66,7 @@ public class DexBackedMethodImplementation implements MethodImplementation {
         return dexFile.getDataBuffer().readUshort(codeOffset);
     }
 
-    protected int getInstructionsSize() {
+    public int getInstructionsSize() {
         return dexFile.getDataBuffer().readSmallUint(codeOffset + CodeItem.INSTRUCTION_COUNT_OFFSET);
     }
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedMethodImplementation.java
@@ -172,13 +172,11 @@ public class DexBackedMethodImplementation implements MethodImplementation {
     /**
      * Calculate and return the private size of a method implementation.
      *
-     * Calculated as: debug info size + instructions size + try-catch size
+     * Calculated as: instructions size + try-catch size
      *
      * @return size in bytes
      */
     public int getSize() {
-        int debugSize = getDebugInfo().getSize();
-
         //set last offset just before bytecode instructions (after insns_size)
         int lastOffset = getInstructionsStartOffset();
 
@@ -195,7 +193,7 @@ public class DexBackedMethodImplementation implements MethodImplementation {
             lastOffset = ((VariableSizeListIterator)tryHandlerIter).getReaderOffset();
         }
 
-        //method impl size = debug block size + code_item size
-        return debugSize + (lastOffset - codeOffset);
+        //method impl size = code_item size
+        return lastOffset - codeOffset;
     }
 }


### PR DESCRIPTION
Two CLs that respectively ignore the debug info event stream past the last instruction pc of a method and that does not add the debug info to the private method size.

Issue https://github.com/JesusFreke/smali/issues/843