### PR TITLE
Change MAX_FILENAME_LENGTH to 180

### DIFF
--- a/util/src/main/java/org/jf/util/ClassFileNameHandler.java
+++ b/util/src/main/java/org/jf/util/ClassFileNameHandler.java
@@ -55,7 +55,7 @@ import static org.jf.util.PathUtil.testCaseSensitivity;
  * - append a '#' if an individual path element would otherwise be considered a reserved filename
  */
 public class ClassFileNameHandler {
-    private static final int MAX_FILENAME_LENGTH = 255;
+    private static final int MAX_FILENAME_LENGTH = 180;
     // How many characters to reserve in the physical filename for numeric suffixes
     // Dex files can currently only have 64k classes, so 5 digits plus 1 for an '#' should
     // be sufficient to handle the case when every class has a conflicting name


### PR DESCRIPTION
On windows, if we put the apk/dex file on desktop or other path such as `C:\Users\xxxxxx\Desktop\folder\test.apk`.
Some dex may produce long file path smali file which cannot handled by Windows application, so shorten the MAX_FILENAME_LENGTH to 180 to make sure that it works in most cases.

Related issue: 
https://github.com/iBotPeaches/Apktool/issues/1582
https://github.com/JesusFreke/smali/issues/541
