### PR TITLE
Fixing missing reference type handling for rewriting purposes

### DIFF
--- a/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedDexFile.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/dexbacked/DexBackedDexFile.java
@@ -257,6 +257,12 @@ public class DexBackedDexFile implements DexFile {
                 return getMethodSection();
             case ReferenceType.FIELD:
                 return getFieldSection();
+            case ReferenceType.METHOD_PROTO:
+                return getMethodSection();
+            case ReferenceType.METHOD_HANDLE:
+                return getMethodHandleSection();
+            case ReferenceType.CALL_SITE:
+                return getCallSiteSection();
             default:
                 throw new IllegalArgumentException(String.format("Invalid reference type: %d", referenceType));
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/CallSiteReferenceRewriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/CallSiteReferenceRewriter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014, Google Inc.
+ * Copyright 2022, Zimperium Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.jf.dexlib2.rewriter;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.jf.dexlib2.base.reference.BaseCallSiteReference;
+import org.jf.dexlib2.iface.reference.CallSiteReference;
+import org.jf.dexlib2.iface.reference.MethodHandleReference;
+import org.jf.dexlib2.iface.reference.MethodProtoReference;
+import org.jf.dexlib2.iface.value.EncodedValue;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public class CallSiteReferenceRewriter implements Rewriter<CallSiteReference> {
+    @Nonnull protected final Rewriters rewriters;
+
+    public CallSiteReferenceRewriter(@Nonnull Rewriters rewriters) {
+        this.rewriters = rewriters;
+    }
+
+    @Nonnull @Override public CallSiteReference rewrite(@Nonnull CallSiteReference callSiteReference) {
+        return new RewrittenCallSiteReference(callSiteReference);
+    }
+
+    protected class RewrittenCallSiteReference extends BaseCallSiteReference {
+        @Nonnull protected CallSiteReference callSiteReference;
+
+        public RewrittenCallSiteReference(@Nonnull CallSiteReference callSiteReference) {
+            this.callSiteReference = callSiteReference;
+        }
+
+        @Override @Nonnull public String getName() {
+            return callSiteReference.getName();
+        }
+
+        @Override @Nonnull public MethodHandleReference getMethodHandle() {
+                return RewriterUtils.rewriteMethodHandleReference(
+                        rewriters, callSiteReference.getMethodHandle());
+        }
+
+        @Override @Nonnull public String getMethodName() {
+            return callSiteReference.getMethodName();
+        }
+
+        @Override @Nonnull public MethodProtoReference getMethodProto() {
+            return RewriterUtils.rewriteMethodProtoReference(
+                        rewriters.getTypeRewriter(),
+                        callSiteReference.getMethodProto());
+        }
+
+        @Override @Nonnull public List<? extends EncodedValue> getExtraArguments() {
+            return Lists.transform(callSiteReference.getExtraArguments(),
+                    new Function<EncodedValue, EncodedValue>() {
+                        @Nonnull @Override public EncodedValue apply(EncodedValue encodedValue) {
+                            return RewriterUtils.rewriteValue(rewriters, encodedValue);
+                        }
+                    });
+        }
+    }
+}

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/DexRewriter.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/DexRewriter.java
@@ -36,6 +36,7 @@ import org.jf.dexlib2.iface.debug.DebugItem;
 import org.jf.dexlib2.iface.instruction.Instruction;
 import org.jf.dexlib2.iface.reference.FieldReference;
 import org.jf.dexlib2.iface.reference.MethodReference;
+import org.jf.dexlib2.iface.reference.CallSiteReference;
 import org.jf.dexlib2.iface.value.EncodedValue;
 
 import javax.annotation.Nonnull;
@@ -79,6 +80,7 @@ public class DexRewriter implements Rewriters {
     private final Rewriter<String> typeRewriter;
     private final Rewriter<FieldReference> fieldReferenceRewriter;
     private final Rewriter<MethodReference> methodReferenceRewriter;
+    private final Rewriter<CallSiteReference> callSiteReferenceRewriter;
     private final Rewriter<Annotation> annotationRewriter;
     private final Rewriter<AnnotationElement> annotationElementRewriter;
     private final Rewriter<EncodedValue> encodedValueRewriter;
@@ -97,6 +99,7 @@ public class DexRewriter implements Rewriters {
         this.typeRewriter = module.getTypeRewriter(this);
         this.fieldReferenceRewriter = module.getFieldReferenceRewriter(this);
         this.methodReferenceRewriter = module.getMethodReferenceRewriter(this);
+        this.callSiteReferenceRewriter = module.getCallSiteReferenceRewriter(this);
         this.annotationRewriter = module.getAnnotationRewriter(this);
         this.annotationElementRewriter = module.getAnnotationElementRewriter(this);
         this.encodedValueRewriter = module.getEncodedValueRewriter(this);
@@ -115,6 +118,7 @@ public class DexRewriter implements Rewriters {
     @Nonnull @Override public Rewriter<String> getTypeRewriter() { return typeRewriter; }
     @Nonnull @Override public Rewriter<FieldReference> getFieldReferenceRewriter() { return fieldReferenceRewriter; }
     @Nonnull @Override public Rewriter<MethodReference> getMethodReferenceRewriter() { return methodReferenceRewriter; }
+    @Nonnull @Override public Rewriter<CallSiteReference> getCallSiteReferenceRewriter() { return callSiteReferenceRewriter; }
     @Nonnull @Override public Rewriter<Annotation> getAnnotationRewriter() { return annotationRewriter; }
     @Nonnull @Override public Rewriter<AnnotationElement> getAnnotationElementRewriter() { return annotationElementRewriter; }
     @Nonnull @Override public Rewriter<EncodedValue> getEncodedValueRewriter() { return encodedValueRewriter; }

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterModule.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterModule.java
@@ -36,6 +36,7 @@ import org.jf.dexlib2.iface.debug.DebugItem;
 import org.jf.dexlib2.iface.instruction.Instruction;
 import org.jf.dexlib2.iface.reference.FieldReference;
 import org.jf.dexlib2.iface.reference.MethodReference;
+import org.jf.dexlib2.iface.reference.CallSiteReference;
 import org.jf.dexlib2.iface.value.EncodedValue;
 
 import javax.annotation.Nonnull;
@@ -91,6 +92,10 @@ public class RewriterModule {
 
     @Nonnull public Rewriter<MethodReference> getMethodReferenceRewriter(@Nonnull Rewriters rewriters) {
         return new MethodReferenceRewriter(rewriters);
+    }
+
+    @Nonnull public Rewriter<CallSiteReference> getCallSiteReferenceRewriter(@Nonnull Rewriters rewriters) {
+        return new CallSiteReferenceRewriter(rewriters);
     }
 
     @Nonnull public Rewriter<Annotation> getAnnotationRewriter(@Nonnull Rewriters rewriters) {

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterUtils.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/RewriterUtils.java
@@ -31,8 +31,22 @@
 
 package org.jf.dexlib2.rewriter;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.jf.util.ExceptionWithContext;
+import org.jf.dexlib2.MethodHandleType;
+import org.jf.dexlib2.ValueType;
+import org.jf.dexlib2.base.reference.BaseMethodHandleReference;
+import org.jf.dexlib2.base.reference.BaseMethodProtoReference;
 import org.jf.dexlib2.base.reference.BaseTypeReference;
+import org.jf.dexlib2.base.value.*;
+import org.jf.dexlib2.iface.reference.FieldReference;
+import org.jf.dexlib2.iface.reference.MethodHandleReference;
+import org.jf.dexlib2.iface.reference.MethodProtoReference;
+import org.jf.dexlib2.iface.reference.MethodReference;
+import org.jf.dexlib2.iface.reference.Reference;
 import org.jf.dexlib2.iface.reference.TypeReference;
+import org.jf.dexlib2.iface.value.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -112,6 +126,119 @@ public class RewriterUtils {
                 return typeRewriter.rewrite(typeReference.getType());
             }
         };
+    }
+
+    @Nonnull public static MethodHandleReference rewriteMethodHandleReference(
+            @Nonnull final Rewriters rewriters,
+            @Nonnull final MethodHandleReference methodHandleReference) {
+        switch (methodHandleReference.getMethodHandleType()) {
+            case MethodHandleType.STATIC_PUT:
+            case MethodHandleType.STATIC_GET:
+            case MethodHandleType.INSTANCE_PUT:
+            case MethodHandleType.INSTANCE_GET:
+                return new BaseMethodHandleReference() {
+                    @Override public int getMethodHandleType() {
+                        return methodHandleReference.getMethodHandleType();
+                    }
+
+                    @Nonnull @Override public Reference getMemberReference() {
+                        return rewriters.getFieldReferenceRewriter().rewrite((FieldReference)methodHandleReference.getMemberReference());
+                    }
+                };
+            case MethodHandleType.INVOKE_STATIC:
+            case MethodHandleType.INVOKE_INSTANCE:
+            case MethodHandleType.INVOKE_CONSTRUCTOR:
+            case MethodHandleType.INVOKE_DIRECT:
+            case MethodHandleType.INVOKE_INTERFACE:
+                return new BaseMethodHandleReference() {
+                    @Override public int getMethodHandleType() {
+                        return methodHandleReference.getMethodHandleType();
+                    }
+
+                    @Nonnull @Override public Reference getMemberReference() {
+                        return rewriters.getMethodReferenceRewriter().rewrite((MethodReference)methodHandleReference.getMemberReference());
+                    }
+                };
+            default:
+                throw new ExceptionWithContext("Invalid method handle type: %d",
+                        methodHandleReference.getMethodHandleType());
+        }
+    }
+
+    @Nonnull public static MethodProtoReference rewriteMethodProtoReference(
+            @Nonnull final Rewriter<String> typeRewriter,
+            @Nonnull final MethodProtoReference methodProtoReference) {
+        return new BaseMethodProtoReference() {
+            @Nonnull @Override public List<? extends CharSequence> getParameterTypes() {
+                return rewriteList(typeRewriter,
+                        Lists.transform(methodProtoReference.getParameterTypes(),
+                        new Function<CharSequence, String>() {
+                            @Nonnull @Override public String apply(CharSequence input) {
+                                return input.toString();
+                            }
+                        }));
+            }
+
+            @Nonnull @Override public String getReturnType() {
+                return typeRewriter.rewrite(methodProtoReference.getReturnType());
+            }
+        };
+    }
+
+    @Nonnull public static EncodedValue rewriteValue(
+            @Nonnull final Rewriters rewriters,
+            @Nonnull final EncodedValue encodedValue) {
+        switch (encodedValue.getValueType()) {
+            case ValueType.INT:
+            case ValueType.FLOAT:
+            case ValueType.LONG:
+            case ValueType.DOUBLE:
+            case ValueType.STRING:
+                return encodedValue;
+
+            case ValueType.METHOD_TYPE:
+                return new BaseMethodTypeEncodedValue () {
+                    @Override @Nonnull public MethodProtoReference getValue() {
+                        return rewriteMethodProtoReference(
+                            rewriters.getTypeRewriter(),
+                            ((MethodTypeEncodedValue) encodedValue).getValue());
+                    }
+                };
+
+            case ValueType.METHOD_HANDLE:
+                return new BaseMethodHandleEncodedValue () {
+                    @Override @Nonnull public MethodHandleReference getValue() {
+                        return rewriteMethodHandleReference(
+                            rewriters,
+                            ((MethodHandleEncodedValue) encodedValue).getValue());
+                    }
+                };
+
+            case ValueType.TYPE:
+                return new BaseTypeEncodedValue () {
+                    @Override @Nonnull public String getValue() {
+                        return rewriters.getTypeRewriter().rewrite(((TypeEncodedValue) encodedValue).getValue());
+                    }
+                };
+
+            case ValueType.FIELD:
+                return new BaseFieldEncodedValue () {
+                    @Override @Nonnull public FieldReference getValue() {
+                        return rewriters.getFieldReferenceRewriter().rewrite(((FieldEncodedValue) encodedValue).getValue());
+                    }
+                };
+
+            case ValueType.METHOD:
+                return new BaseMethodEncodedValue () {
+                    @Override @Nonnull public MethodReference getValue() {
+                        return rewriters.getMethodReferenceRewriter().rewrite(((MethodEncodedValue) encodedValue).getValue());
+                    }
+                };
+
+            default:
+                throw new ExceptionWithContext("Unsupported encoded value type: %d",
+                        encodedValue.getValueType());
+        }
     }
 }
 

--- a/dexlib2/src/main/java/org/jf/dexlib2/rewriter/Rewriters.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/rewriter/Rewriters.java
@@ -36,6 +36,7 @@ import org.jf.dexlib2.iface.debug.DebugItem;
 import org.jf.dexlib2.iface.instruction.Instruction;
 import org.jf.dexlib2.iface.reference.FieldReference;
 import org.jf.dexlib2.iface.reference.MethodReference;
+import org.jf.dexlib2.iface.reference.CallSiteReference;
 import org.jf.dexlib2.iface.value.EncodedValue;
 
 import javax.annotation.Nonnull;
@@ -56,6 +57,7 @@ public interface Rewriters {
     @Nonnull Rewriter<String> getTypeRewriter();
     @Nonnull Rewriter<FieldReference> getFieldReferenceRewriter();
     @Nonnull Rewriter<MethodReference> getMethodReferenceRewriter();
+    @Nonnull Rewriter<CallSiteReference> getCallSiteReferenceRewriter();
 
     @Nonnull Rewriter<Annotation> getAnnotationRewriter();
     @Nonnull Rewriter<AnnotationElement> getAnnotationElementRewriter();

--- a/dexlib2/src/main/java/org/jf/dexlib2/util/Preconditions.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/util/Preconditions.java
@@ -271,6 +271,21 @@ public class Preconditions {
                     throw new IllegalArgumentException("Invalid reference type, expecting a method reference");
                 }
                 break;
+            case ReferenceType.METHOD_PROTO:
+                if (!(reference instanceof MethodProtoReference)) {
+                    throw new IllegalArgumentException("Invalid reference type, expecting a method proto reference");
+                }
+                break;
+            case ReferenceType.METHOD_HANDLE:
+                if (!(reference instanceof MethodHandleReference)) {
+                    throw new IllegalArgumentException("Invalid reference type, expecting a method handle reference");
+                }
+                break;
+            case ReferenceType.CALL_SITE:
+                if (!(reference instanceof CallSiteReference)) {
+                    throw new IllegalArgumentException("Invalid reference type, expecting a call site reference");
+                }
+                break;
             default:
                 throw new IllegalArgumentException(String.format("Not a valid reference type: %d", referenceType));
         }

--- a/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/ClassPool.java
+++ b/dexlib2/src/main/java/org/jf/dexlib2/writer/pool/ClassPool.java
@@ -173,6 +173,9 @@ public class ClassPool extends BasePool<String, PoolClassDef> implements ClassSe
             case ReferenceType.METHOD_PROTO:
                 dexPool.protoSection.intern((MethodProtoReference)reference);
                 break;
+            case ReferenceType.METHOD_HANDLE:
+                dexPool.methodHandleSection.intern((MethodHandleReference) reference);
+                break;
             case ReferenceType.CALL_SITE:
                 dexPool.callSiteSection.intern((CallSiteReference) reference);
                 break;


### PR DESCRIPTION
During some DEX rewriting using the latest features, exceptions get thrown because of missing handling of some reference types.

Fixed that, and also went through the code to fix all other missing stuff. In some cases, maybe no real opcode would be coded such way that some code path would be triggered, but this way is more safe.

Also, likely fixed a bug of interning METHOD_HANDLE type.