### PR TITLE
Fix build scripts to work with Gradle 9.1.0 without errors

### DIFF
--- a/baksmali/build.gradle
+++ b/baksmali/build.gradle
@@ -57,7 +57,7 @@ task fatJar(type: Jar) {
     from sourceSets.main.output
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
 
-    classifier = 'fat'
+    archiveClassifier = 'fat'
 
     manifest {
         attributes('Main-Class': 'org.jf.baksmali.Main')
@@ -65,9 +65,12 @@ task fatJar(type: Jar) {
 
     doLast {
         if (!System.getProperty('os.name').toLowerCase().contains('windows')) {
-            ant.symlink(link: file("${destinationDirectory.get()}/baksmali.jar"), resource: archivePath, overwrite: true)
+            ant.symlink(link: file("${destinationDirectory.get()}/baksmali.jar"), resource: archiveFile.get().asFile, overwrite: true)
         }
     }
+
+	dependsOn ':util:jar'
+	dependsOn ':dexlib2:jar'
 }
 tasks.getByPath('build').dependsOn(fatJar)
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@
 
 apply plugin: 'idea'
 
+
+
 version = '2.5.2'
 def jcommanderVersion = ''
 
@@ -71,9 +73,16 @@ task(install).doLast {
 // The projects that get pushed to maven
 def maven_release_projects = ['smali', 'baksmali', 'dexlib2', 'util']
 
+
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'idea'
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
 
     if (JavaVersion.current().isJava8Compatible()) {
         allprojects {
@@ -86,8 +95,8 @@ subprojects {
     version = parent.version
 
     java {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     ext {
@@ -100,7 +109,7 @@ subprojects {
                 antlr: 'org.antlr:antlr:3.5.2',
                 stringtemplate: 'org.antlr:stringtemplate:3.2.1',
                 jflex_plugin: 'org.xbib.gradle.plugin:gradle-plugin-jflex:1.1.0',
-                proguard_gradle: 'net.sf.proguard:proguard-gradle:6.2.2',
+                proguard_gradle: 'com.guardsquare:proguard-gradle:7.5.0',
                 dx: 'com.google.android.tools:dx:1.7',
                 gson: 'com.google.code.gson:gson:2.3.1',
                 jcommander: jcommanderVersion
@@ -170,7 +179,7 @@ subprojects {
         }
 
         signing {
-            required { gradle.taskGraph.hasTask('publish') }
+            required = gradle.taskGraph.hasTask('publish')
             sign(publishing.publications["mavenJava"])
         }
 

--- a/dexlib2/build.gradle
+++ b/dexlib2/build.gradle
@@ -40,6 +40,13 @@ sourceSets {
     }
 }
 
+test {
+    jvmArgs += [
+        '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+        '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+    ]
+}
+
 configurations {
     accessorTestGenerator
     dx
@@ -71,7 +78,7 @@ task generateAccessorTestSource(type: JavaExec) {
     outputs.dir file(testAccessorOutputDir)
 
     classpath = configurations.accessorTestGenerator
-    main = 'org.jf.dexlib2.AccessorTestGenerator'
+    mainClass = 'org.jf.dexlib2.AccessorTestGenerator'
     args testAccessorOutputFile
 }
 compileAccessorTestJava.dependsOn(generateAccessorTestSource)
@@ -84,7 +91,7 @@ task generateAccessorTestDex(type: JavaExec, dependsOn: compileAccessorTestJava)
     inputs.dir(project.sourceSets.accessorTest.output.classesDirs)
     outputs.file outputDex
 
-    main 'com.android.dx.command.Main'
+    mainClass = 'com.android.dx.command.Main'
     classpath = configurations.dx
 
     args '--dex'

--- a/smali/build.gradle
+++ b/smali/build.gradle
@@ -48,11 +48,17 @@ configurations {
     implementation.exclude group: 'org.antlr', module: 'antlr'
 }
 
+compileJava.dependsOn(generateGrammarSource, jflex)
+
 sourceSets {
     main {
         resources {
             // This adds the generated .tokens files to the jar
             srcDir 'build/generated-src/antlr/main'
+        }
+		java {
+            srcDir 'build/generated-src/antlr/main'
+            srcDir 'build/generated-src/jflex'
         }
     }
 }
@@ -63,7 +69,8 @@ idea {
         if (buildDir.exists()) {
             excludeDirs.addAll(buildDir.listFiles())
         }
-        for (sourceDir in (sourceDirs + testSourceDirs)) {
+		def allSourceDirs = project.sourceSets.main.allSource.srcDirs + project.sourceSets.test.allSource.srcDirs
+        for (sourceDir in allSourceDirs) {
             excludeDirs.remove(sourceDir);
             while ((sourceDir = sourceDir.getParentFile()) != null) {
                 excludeDirs.remove(sourceDir);
@@ -87,21 +94,24 @@ dependencies {
 
 processResources.inputs.property('version', version)
 processResources.expand('version': version)
+processResources.dependsOn(generateGrammarSource)
 
 // Build a separate jar that contains all dependencies
-task fatJar(type: Jar, dependsOn: jar) {
+task fatJar(type: Jar, dependsOn: [jar, ':util:jar', ':dexlib2:jar']) {
     from sourceSets.main.output
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
 
-    classifier = 'fat'
+    archiveClassifier = 'fat'
 
     manifest {
         attributes('Main-Class': 'org.jf.smali.Main')
     }
 
     doLast {
+		def rootLibsDirProvider = rootProject.layout.buildDirectory.dir('libs')
         if (!System.getProperty('os.name').toLowerCase().contains('windows')) {
-            ant.symlink(link: file("${destinationDirectory.get()}/smali.jar"), resource: archivePath, overwrite: true)
+            mkdir rootLibsDirProvider.get()
+            ant.symlink(link: file("${rootLibsDirProvider.get()}/smali.jar"), resource: archiveFile.get().asFile, overwrite: true)
         }
     }
 }
@@ -160,6 +170,7 @@ task proguard(type: proguard.gradle.ProGuardTask, dependsOn: fatJar) {
 
 sourcesJar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+	dependsOn jflex, generateGrammarSource
 }
 
 tasks.getByPath(':release').dependsOn(proguard)


### PR DESCRIPTION
Currently, attempting to build this with a modern Gradle installation causes myriad build errors. At the same time, attempting to use old build tools in a modern environment is challenging, and causes different issues. This change fixes the build scripts to work with Gradle 9.1.0 without errors or warnings.